### PR TITLE
update to FeatureRequirement>placesToLookForPackagesDo: to facilitate Cuis dev guidelines

### DIFF
--- a/CoreUpdates/1868-CuisCore-DavidGraham-2013Dec03-10h56m-DSG.1.cs.st
+++ b/CoreUpdates/1868-CuisCore-DavidGraham-2013Dec03-10h56m-DSG.1.cs.st
@@ -1,0 +1,28 @@
+'From Cuis 4.2 of 25 July 2013 [latest update: #1867] on 3 December 2013 at 10:57:19.16892 am'!
+
+!FeatureRequirement methodsFor: 'private' stamp: 'DSG 12/3/2013 10:56'!
+placesToLookForPackagesDo: aBlock
+
+	| base pckDir myDir |
+	"Look in Cuis image folder"
+	base _ FileDirectory default.
+	aBlock value: base.
+
+	"Look in the usual Packages subfolder"
+	pckDir _ base directoryNamed: 'Packages'.
+	pckDir exists ifTrue: [
+		aBlock value: pckDir ].
+
+	"Look inside my own folder, if different"
+	pathName ifNotNil: [
+		myDir _ FileDirectory on: (FileDirectory dirPathFor: pathName).
+		(myDir ~= base and: [ myDir ~= pckDir ]) ifTrue: [
+			aBlock value: myDir ]].
+
+	"Finally look in any subfolders that follow the convention of naming package repositories with the 'Cuis-Smalltalk' prefix"
+	self cuisAndCuisPackagesSubdirectoriesOf: FileDirectory default do: aBlock.
+	"Finally look in any sibling folders that follow the convention of naming package repositories with the 'Cuis-Smalltalk' prefix"
+	self cuisAndCuisPackagesSubdirectoriesOf: FileDirectory default containingDirectory do: aBlock.
+	"If you are working from a newImage directory,  recurse one more level into any sibling folders that follow the convention of naming package repositories with the 'Cuis-Smalltalk' prefix"
+	self cuisAndCuisPackagesSubdirectoriesOf: FileDirectory default containingDirectory containingDirectory do: aBlock! !
+


### PR DESCRIPTION
updated FeatureRequirement>placesToLookForPackagesDo: to recurse one more directory.  This is needed if following the 'Code Management in Cuis 4.0' guidelines and using newImage to create dev images.
