### PR TITLE
Update getCog.sh

### DIFF
--- a/bin/getCog.sh
+++ b/bin/getCog.sh
@@ -5,6 +5,6 @@ case "$OSTYPE" in
 	darwin*) NAME="Cog.app" ;;
 	*) NAME="coglinux" ;;
 esac
-curl http://www.mirandabanda.org/files/Cog/VM/VM.r$BUILD/$NAME-$VERSION.$BUILD.tgz -o Cog.$BUILD.tgz
+curl http://www.mirandabanda.org/files/Cog/VM/2014/VM.r$BUILD/$NAME-$VERSION.$BUILD.tgz -o Cog.$BUILD.tgz
 tar -xf Cog.$BUILD.tgz
 rm Cog.$BUILD.tgz


### PR DESCRIPTION
Either use a newer vm, then the year is not needed, or add the year part of the path