### PR TITLE
Changes to BouncingAtoms, ClassCommentBrowser, and TerseGuide

### DIFF
--- a/Packages/BouncingAtoms.pck.st
+++ b/Packages/BouncingAtoms.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2763] on 12 May 2016 at 6:24:24.663592 pm'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2763] on 12 May 2016 at 6:38:13.380592 pm'!
 'Description A port of Bouncing Atoms with the atoms in a SystemWindow. A pop-up menu enables selection of options, including an active plot of infection history, also in a SystemWindow.'!
-!provides: 'BouncingAtoms' 1 24!
+!provides: 'BouncingAtoms' 1 25!
 !requires: 'Morphic-Widgets-Extras' 1 0 nil!
 !classDefinition: #AtomMorph category: #BouncingAtoms!
 EllipseMorph subclass: #AtomMorph
@@ -30,16 +30,6 @@ RectangleLikeMorph subclass: #BouncingAtomsMorph
 	category: 'BouncingAtoms'!
 !classDefinition: 'BouncingAtomsMorph class' category: #BouncingAtoms!
 BouncingAtomsMorph class
-	instanceVariableNames: ''!
-
-!classDefinition: #GraphMorph category: #BouncingAtoms!
-FunctionGraphMorph subclass: #GraphMorph
-	instanceVariableNames: 'data points yScaleFactor'
-	classVariableNames: ''
-	poolDictionaries: ''
-	category: 'BouncingAtoms'!
-!classDefinition: 'GraphMorph class' category: #BouncingAtoms!
-GraphMorph class
 	instanceVariableNames: ''!
 
 !classDefinition: #InfectionGraph category: #BouncingAtoms!
@@ -83,9 +73,6 @@ This morph shows how simulation of an ideal gas might work. When the morph gets 
      add a Heater/Cooler Atom(s), then
      start an infection and note the effect as atoms pass over the Heater/Cooler Atom(s).
   8. Repeatedly start an infection with the same atoms from step 7.!
-
-!GraphMorph commentStamp: '<historical>' prior: 0!
-Normalize points in a collection, plot them in a graph, with lines drawn between them.!
 
 !InfectionGraph commentStamp: 'dhn 5/11/2016 15:55' prior: 0!
 Normalize the number of infected atoms, treat them as a time series, and plot them in a graph.!
@@ -537,85 +524,6 @@ open
 "
 
 	self initializedInstance openInHand! !
-
-!GraphMorph methodsFor: 'drawing' stamp: 'dhn 5/26/2015 20:12'!
-asNormalizedPoints: aCollection
-	"Answer an array of points which are mapped on [0, T] in both dimensions, where T is a multiple of 10"
-	| yArray yFactor xArray xFactor result |
-	yFactor _ 10 raisedTo: yMax log asInteger.
-	yArray _ yFactor * (self normalize: aCollection asOrderedCollection with: yScaleFactor).
-	xFactor _ 10 raisedTo: xMax log asInteger.
-	xArray _ xFactor * (self normalize: (0 to: aCollection size) asArray).
-	result _ OrderedCollection new.
-	1
-		to: yArray size
-		do: [ :i |
-			result add: (xArray at: i) @ (yArray at: i) ].
-	^ result.! !
-
-!GraphMorph methodsFor: 'accessing' stamp: 'dhn 5/6/2015 09:33'!
-color: aColor
-
-	super color: aColor.
-! !
-
-!GraphMorph methodsFor: 'accessing' stamp: 'dhn 5/23/2015 16:09'!
-data: aCollection
-
-	data _ aCollection
-! !
-
-!GraphMorph methodsFor: 'drawing' stamp: 'dhn 5/29/2015 18:21'!
-drawOn: aCanvas
-	| fully |
-	fully _ 10 raisedTo: yMax log asInteger.
-
-	aCanvas line: (self toMorphic:0@yMin) to: (self toMorphic: 0 @ yMax) width: 2 color: Color lightGray.
-	aCanvas line: (self toMorphic: xMin@0) to: (self toMorphic: xMax@0) width: 2 color: Color lightGray.
-	aCanvas line: (self toMorphic: 0@fully) to: (self toMorphic: xMax@fully) width: 2 color: Color lightRed.
-
-	points ifNotNil: [
-		1 to: points size - 1 do: [:n |
-			aCanvas line: (self toMorphic: (points at: n)) to: (self toMorphic: (points at: n + 1)) width: 2 color: Color black]]! !
-
-!GraphMorph methodsFor: 'initialization' stamp: 'dhn 5/23/2015 16:02'!
-initialize
-
-	super initialize
-! !
-
-!GraphMorph methodsFor: 'drawing' stamp: 'dhn 5/23/2015 11:50'!
-normalize: aCollection
-	"Answer aCollection divided by its maximum"
-	| max |
-	max _ aCollection inject: 0 into: [:a :c | (a > c)
-		ifTrue: [a]
-		ifFalse: [c]].
-	^ OrderedCollection new
-		addAll: aCollection / (max * 1.0)! !
-
-!GraphMorph methodsFor: 'drawing' stamp: 'dhn 5/26/2015 20:09'!
-normalize: aCollection with: aFactor
-	"Answer aCollection divided by its maximum and scaled by maximum/aFactor"
-	| max |
-	max _ aCollection inject: 0 into: [:a :c | (a > c)
-		ifTrue: [a]
-		ifFalse: [c]].
-	^ OrderedCollection new
-		addAll: (aCollection / (max * 1.0)) * (max / aFactor)! !
-
-!GraphMorph methodsFor: 'drawing' stamp: 'dhn 5/26/2015 12:18'!
-update: aSymbol
-	"Re-normalize data if parameter = #redraw"
-	super update: aSymbol.
-	(aSymbol == #redraw and: (data size > 1)) ifTrue: [points _ self asNormalizedPoints: data]
-! !
-
-!GraphMorph methodsFor: 'accessing' stamp: 'dhn 5/26/2015 12:25'!
-yScaleFactor: aNumber
-
-	yScaleFactor _ aNumber
-! !
 
 !InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/12/2016 10:50'!
 asNormalizedPoints: aCollection

--- a/Packages/BouncingAtoms.pck.st
+++ b/Packages/BouncingAtoms.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2761] on 10 May 2016 at 9:41:54.885995 am'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2763] on 12 May 2016 at 6:24:24.663592 pm'!
 'Description A port of Bouncing Atoms with the atoms in a SystemWindow. A pop-up menu enables selection of options, including an active plot of infection history, also in a SystemWindow.'!
-!provides: 'BouncingAtoms' 1 23!
+!provides: 'BouncingAtoms' 1 24!
 !requires: 'Morphic-Widgets-Extras' 1 0 nil!
 !classDefinition: #AtomMorph category: #BouncingAtoms!
 EllipseMorph subclass: #AtomMorph
@@ -42,6 +42,16 @@ FunctionGraphMorph subclass: #GraphMorph
 GraphMorph class
 	instanceVariableNames: ''!
 
+!classDefinition: #InfectionGraph category: #BouncingAtoms!
+FunctionGraphMorph subclass: #InfectionGraph
+	instanceVariableNames: 'data points yScaleFactor startTime deltaT ticN tics yFactor xFactor'
+	classVariableNames: ''
+	poolDictionaries: ''
+	category: 'BouncingAtoms'!
+!classDefinition: 'InfectionGraph class' category: #BouncingAtoms!
+InfectionGraph class
+	instanceVariableNames: ''!
+
 
 !AtomMorph commentStamp: '<historical>' prior: 0!
 AtomMorph represents an atom used in the simulation of
@@ -76,6 +86,9 @@ This morph shows how simulation of an ideal gas might work. When the morph gets 
 
 !GraphMorph commentStamp: '<historical>' prior: 0!
 Normalize points in a collection, plot them in a graph, with lines drawn between them.!
+
+!InfectionGraph commentStamp: 'dhn 5/11/2016 15:55' prior: 0!
+Normalize the number of infected atoms, treat them as a time series, and plot them in a graph.!
 
 !AtomMorph methodsFor: 'private' stamp: 'jm 8/10/1998 17:40'!
 bounceIn: aRect
@@ -415,14 +428,15 @@ setAtomCount
 	self reset.
 	self startStepping.! !
 
-!BouncingAtomsMorph methodsFor: 'menu' stamp: 'dhn 5/26/2015 19:49'!
+!BouncingAtomsMorph methodsFor: 'menu' stamp: 'dhn 5/11/2016 21:17'!
 showInfectionHistory
 	"Show a graph of the infection history"
-	historyWindow _ GraphMorph new.
+	historyWindow _ InfectionGraph new.
 	historyWindow 
 		data: infectionHistory;
 		yScaleFactor: nAtoms;
 		domain: (-0.8 to: 11);
+		setXYFactors;
 		update: #redraw.
 	(historyWindow embeddedInMorphicWindowLabeled: 'Infection History') openInWorld
 ! !
@@ -602,3 +616,165 @@ yScaleFactor: aNumber
 
 	yScaleFactor _ aNumber
 ! !
+
+!InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/12/2016 10:50'!
+asNormalizedPoints: aCollection
+	"Answer an array of points which are mapped on [0, T] in both dimensions, where T is a multiple of 10"
+	| yArray xArray result |
+	
+	aCollection size == 2 ifTrue: [
+		self ticN: 1000.
+		self startTime: Time localMillisecondClock.
+		tics _ OrderedCollection new].
+	((deltaT _ Time localMillisecondClock - self startTime) > self ticN) ifTrue: [
+		self tics add: aCollection size.
+		ticN _ ticN + 1000].
+	yArray _ yFactor * (self normalize: aCollection asOrderedCollection with: yScaleFactor).
+	xArray _ xFactor * (self normalize: (0 to: aCollection size) asArray).
+	
+	result _ OrderedCollection new.
+	1 to: yArray size	do: [ :i | result add: (xArray at: i) @ (yArray at: i) ].
+	
+	^ result.! !
+
+!InfectionGraph methodsFor: 'accessing' stamp: 'dhn 5/6/2015 09:33'!
+color: aColor
+
+	super color: aColor.
+! !
+
+!InfectionGraph methodsFor: 'accessing' stamp: 'dhn 5/11/2016 02:06'!
+data
+	"Answer the value of data"
+
+	^ data! !
+
+!InfectionGraph methodsFor: 'accessing' stamp: 'dhn 5/23/2015 16:09'!
+data: aCollection
+
+	data _ aCollection
+! !
+
+!InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/12/2016 12:28'!
+drawOn: aCanvas
+	| fully |
+	fully _ 10 raisedTo: yMax log asInteger.
+
+	aCanvas line: (self toMorphic:0@yMin) to: (self toMorphic: 0 @ yMax) width: 2 color: Color lightGray.
+	aCanvas line: (self toMorphic: xMin@0) to: (self toMorphic: xMax@0) width: 2 color: Color lightGray.
+	aCanvas line: (self toMorphic: 0@fully) to: (self toMorphic: xMax@fully) width: 2 color: Color lightRed.
+
+	points ifNotNil: [
+		1 to: points size - 1 do: [:n | | p |
+			aCanvas 	"continue the graph"
+				line: (self toMorphic: (p _ points at: n)) 	"from point"
+				to: (self toMorphic: (points at: n + 1)) 	"to point"
+				width: 2 color: Color black.
+			(self tics includes: n) ifTrue: [
+				aCanvas 	"plot the tic"
+					line: (self toMorphic: (p x) @ 0) 
+					to: (self toMorphic: (p x) @ (self class ticLength)) 
+					width: 2 color: Color lightGray]]]! !
+
+!InfectionGraph methodsFor: 'initialization' stamp: 'dhn 5/12/2016 09:50'!
+initialize
+
+	super initialize! !
+
+!InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/23/2015 11:50'!
+normalize: aCollection
+	"Answer aCollection divided by its maximum"
+	| max |
+	max _ aCollection inject: 0 into: [:a :c | (a > c)
+		ifTrue: [a]
+		ifFalse: [c]].
+	^ OrderedCollection new
+		addAll: aCollection / (max * 1.0)! !
+
+!InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/26/2015 20:09'!
+normalize: aCollection with: aFactor
+	"Answer aCollection divided by its maximum and scaled by maximum/aFactor"
+	| max |
+	max _ aCollection inject: 0 into: [:a :c | (a > c)
+		ifTrue: [a]
+		ifFalse: [c]].
+	^ OrderedCollection new
+		addAll: (aCollection / (max * 1.0)) * (max / aFactor)! !
+
+!InfectionGraph methodsFor: 'accessing' stamp: 'dhn 5/11/2016 02:06'!
+points
+	"Answer the value of points"
+
+	^ points! !
+
+!InfectionGraph methodsFor: 'accessing' stamp: 'dhn 5/11/2016 02:06'!
+points: anObject
+	"Set the value of points"
+
+	points _ anObject! !
+
+!InfectionGraph methodsFor: 'initialization' stamp: 'dhn 5/11/2016 21:17'!
+setXYFactors
+	"Set the values of xFactor and yFactor"
+
+	xFactor _ 10 raisedTo: xMax log asInteger.
+	yFactor _ 10 raisedTo: yMax log asInteger
+! !
+
+!InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/12/2016 10:39'!
+startTime
+	"Answer the value of startTime"
+	
+	startTime ifNil: [startTime _ Time localMillisecondClock].
+	^ startTime! !
+
+!InfectionGraph methodsFor: 'accessing' stamp: 'dhn 5/11/2016 02:06'!
+startTime: anObject
+	"Set the value of startTime"
+
+	startTime _ anObject! !
+
+!InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/12/2016 10:49'!
+ticN
+	"Answer the value of ticN"
+	
+	ticN ifNil: [ticN _ 1000].
+	^ ticN! !
+
+!InfectionGraph methodsFor: 'accessing' stamp: 'dhn 5/12/2016 10:15'!
+ticN: anObject
+	"Set the value of ticN"
+
+	ticN _ anObject! !
+
+!InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/12/2016 10:19'!
+tics
+	"Answer the value of tics"
+	
+	tics ifNil: [tics _ OrderedCollection new].
+	^ tics! !
+
+!InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/26/2015 12:18'!
+update: aSymbol
+	"Re-normalize data if parameter = #redraw"
+	super update: aSymbol.
+	(aSymbol == #redraw and: (data size > 1)) ifTrue: [points _ self asNormalizedPoints: data]
+! !
+
+!InfectionGraph methodsFor: 'accessing' stamp: 'dhn 5/11/2016 02:06'!
+yScaleFactor
+	"Answer the value of yScaleFactor"
+
+	^ yScaleFactor! !
+
+!InfectionGraph methodsFor: 'accessing' stamp: 'dhn 5/26/2015 12:25'!
+yScaleFactor: aNumber
+
+	yScaleFactor _ aNumber
+! !
+
+!InfectionGraph class methodsFor: 'display' stamp: 'dhn 5/11/2016 16:01'!
+ticLength
+	"Answer the length of tic marks"
+	
+	^ 0.2! !

--- a/Packages/ClassCommentBrowser.pck.st
+++ b/Packages/ClassCommentBrowser.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2713] on 2 April 2016 at 10:51:13.699672 pm'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2763] on 14 May 2016 at 10:51:03.972057 am'!
 'Description Browse class comments for classes with names such as "Pluggable," "Morphic," "Text," or "Morph" which appear in a hierarchical list.'!
-!provides: 'ClassCommentBrowser' 1 28!
+!provides: 'ClassCommentBrowser' 1 29!
 !classDefinition: #CommentGuide category: #ClassCommentBrowser!
 AbstractHierarchicalList subclass: #CommentGuide
 	instanceVariableNames: 'window rootNames root browser subList index key'
@@ -425,24 +425,24 @@ respondToKey: aChar
 	model indexOf: aChar.
 	listMorph update: #keySelection! !
 
-!CommentGuideWindow methodsFor: 'searching' stamp: 'dhn 9/21/2015 19:31'!
+!CommentGuideWindow methodsFor: 'searching' stamp: 'dhn 5/14/2016 10:47'!
 searchAllComments
 	"Search for a string in class comments of all classes"
-	| arg hits menu |
+	| arg hits caption items n |
+	
 	arg _ ''.
-		arg _ FillInTheBlankMorph request: 'Search All Class Comments for:'.
-		(menu _ MenuMorph entitled: 'Comments of All Classes with "', arg, '"')
-			defaultTarget: self;
-			addStayUpIcons.
+	arg _ FillInTheBlankMorph request: 'Search All Class Comments for:'.
+	caption _ 'Classes with Comments containing "', arg, '"'.
 			
-		hits _ self searchIn: Smalltalk classNames for: arg.
-		hits 
-			ifEmpty: [listMorph flash]
-			ifNotEmpty: [
-				hits do: [:h | menu add: h selector: #showFind: argument: h].
-				menu 
-					openInWorld;
-					morphPosition: self morphPosition + (-70@50)].
+	hits _ self searchIn: Smalltalk classNames for: arg.
+	hits 
+		ifEmpty: [listMorph flash]
+		ifNotEmpty: [
+			items _ String streamContents: [:s | hits do: [:i | s nextPutAll: i asString; newLine]].
+			n _ (PopUpMenu labels: items lines: nil)
+				startUpWithCaption: caption.
+			self showFind: (hits at: n) "show the comment of the selected class" ].
+					
 	^ nil! !
 
 !CommentGuideWindow methodsFor: 'searching' stamp: 'dhn 9/21/2015 16:50'!

--- a/Packages/ClassCommentBrowser.pck.st
+++ b/Packages/ClassCommentBrowser.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2763] on 14 May 2016 at 10:51:03.972057 am'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2763] on 16 May 2016 at 6:02:36.088656 pm'!
 'Description Browse class comments for classes with names such as "Pluggable," "Morphic," "Text," or "Morph" which appear in a hierarchical list.'!
-!provides: 'ClassCommentBrowser' 1 29!
+!provides: 'ClassCommentBrowser' 1 30!
 !classDefinition: #CommentGuide category: #ClassCommentBrowser!
 AbstractHierarchicalList subclass: #CommentGuide
 	instanceVariableNames: 'window rootNames root browser subList index key'
@@ -425,7 +425,24 @@ respondToKey: aChar
 	model indexOf: aChar.
 	listMorph update: #keySelection! !
 
-!CommentGuideWindow methodsFor: 'searching' stamp: 'dhn 5/14/2016 10:47'!
+!CommentGuideWindow methodsFor: 'browsing' stamp: 'dhn 5/16/2016 17:54'!
+scrollToClass: aString
+	"Scroll to an entry for the class named aString"
+	| cat m1 m2 |
+	
+	cat _ (model parseName: aString) first.
+	m1 _ listMorph findDeepSubmorphThat: [:ea | 
+		(ea respondsTo: #contents) and: [ea contents includesSubString: cat]] ifAbsent: [nil].
+	m1 ifNotNil: [m1 isExpanded ifFalse: [listMorph toggleExpandedState: m1]].
+		
+	m2 _ listMorph findDeepSubmorphThat: [:ea | 
+		(ea respondsTo: #contents) and: [ea contents includesSubString: aString]] ifAbsent: [nil].
+	m2 ifNotNil: [
+		listMorph 
+			setSelectedMorph: m2;
+			scrollSelectionIntoView]! !
+
+!CommentGuideWindow methodsFor: 'searching' stamp: 'dhn 5/16/2016 16:30'!
 searchAllComments
 	"Search for a string in class comments of all classes"
 	| arg hits caption items n |
@@ -441,7 +458,9 @@ searchAllComments
 			items _ String streamContents: [:s | hits do: [:i | s nextPutAll: i asString; newLine]].
 			n _ (PopUpMenu labels: items lines: nil)
 				startUpWithCaption: caption.
-			self showFind: (hits at: n) "show the comment of the selected class" ].
+			self 
+				scrollToClass: (hits at: n);
+				showFind: (hits at: n) "show the comment of the selected class" ].
 					
 	^ nil! !
 
@@ -508,12 +527,11 @@ searchIn: aCollection for: aString
 			ifTrue: [hits addLast: ea]].
 	^ hits! !
 
-!CommentGuideWindow methodsFor: 'browsing' stamp: 'dhn 9/10/2015 21:11'!
+!CommentGuideWindow methodsFor: 'browsing' stamp: 'dhn 5/16/2016 17:57'!
 showFind: aName
 	"Cause the class comment for aName to display"
-	| str |
-	str _ model commentOf: aName.
-	textMorph model actualContents: str! !
+
+	textMorph model actualContents: (model commentOf: aName)! !
 
 !CommentGuideWindow methodsFor: 'accessing' stamp: 'dhn 8/19/2015 19:47'!
 textMorph

--- a/Packages/TerseGuide.pck.st
+++ b/Packages/TerseGuide.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2701] on 17 March 2016 at 9:09:45.239894 pm'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2763] on 14 May 2016 at 11:34:05.159057 am'!
 'Description Displays topics to aid the writing of Smalltalk code for Cuis.'!
-!provides: 'TerseGuide' 1 108!
+!provides: 'TerseGuide' 1 109!
 !classDefinition: #TerseGuideHelp category: #TerseGuide!
 Workspace subclass: #TerseGuideHelp
 	instanceVariableNames: 'topics topicListIndex selectedTopic topicList window textPane'
@@ -1807,7 +1807,7 @@ x _ 20@5 dotProduct: 10@2.					"sum of product (x1*x2 + y1*y2)"
 
 '! !
 
-!TerseGuideHelp class methodsFor: 'pages' stamp: 'dhn 3/8/2015 15:30'!
+!TerseGuideHelp class methodsFor: 'pages' stamp: 'dhn 5/14/2016 11:29'!
 popUpMenu
 	"PopUpMenu"
 	^
@@ -1828,8 +1828,13 @@ x _ (PopUpMenu labelArray: arr lines: lin)
 	at: 450@200
 	allowKeyboard: false.
 y _ (PopUpMenu withCaption: ''Special'' chooseFrom: ''Alpha\Beta\Gamma\something else'').
+
 x _ FillInTheBlankMorph request: ''Enter the (whatever)'' initialAnswer: ''the default''.
 		"when it is not possible to pre-determine an answer"
+		
+"For potentially long menus, the following includes ''more...'' and ''start over...'' behavior"
+x _ (PopUpMenu labels: (String streamContents: [:s | 1 to: 100 do: [:i | s print: i; newLine]])
+		lines: (5 to: 100 by: 5)) startUpWithCaption: ''Long Menu Example''.		
 '! !
 
 !TerseGuideHelp class methodsFor: 'pages' stamp: 'dhn 3/1/2015 12:58'!

--- a/Packages/TerseGuide.pck.st
+++ b/Packages/TerseGuide.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2763] on 14 May 2016 at 11:34:05.159057 am'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2763] on 14 May 2016 at 6:27:09.354057 pm'!
 'Description Displays topics to aid the writing of Smalltalk code for Cuis.'!
-!provides: 'TerseGuide' 1 109!
+!provides: 'TerseGuide' 1 110!
 !classDefinition: #TerseGuideHelp category: #TerseGuide!
 Workspace subclass: #TerseGuideHelp
 	instanceVariableNames: 'topics topicListIndex selectedTopic topicList window textPane'
@@ -1641,7 +1641,7 @@ Smalltalk condenseChanges.					"compress the change file"
 x _ FillInTheBlankMorph request: ''Prompt Me''.		"prompt user for input"
 '! !
 
-!TerseGuideHelp class methodsFor: 'pages' stamp: 'dhn 3/15/2016 14:05'!
+!TerseGuideHelp class methodsFor: 'pages' stamp: 'dhn 5/14/2016 18:22'!
 morph
 	"Morphs"
 	^
@@ -1654,6 +1654,7 @@ x name: #MyName.		"used in the halos"
 x name: ''My Name''.			"alternative, allowing imbedded blanks"
 x morphPosition: 100@65.	"set the morph location"
 y _ FillInTheBlankMorph request: ''Please Enter Something''.	"prompt user for input"
+Feature require: #''Morphic-Widgets-Extras''.	"ensure a requirement is available for the following plot"
 x _ FunctionGraphMorph example2.	"plot two functions"
 x _ SystemWindow new openInWorld.	"open a window"
 x setLabel: ''Label for It''.


### PR DESCRIPTION
In BouncingAtoms package, infection history displays one-second tic marks on the x-axis.

In ClassCommentBrowser, long menu lists have "more..." and "start over..." behavior.

In TerseGuide, the PopupMenu topic includes a #labels:Lines: example to feature a menu with the handy but hard to find "more..." and "start over..." behavior.