### PR TITLE
In ClassCommentBrowser, improve the scroll to the selected class. Update TerseGuide Internal Streams  and String.

### DIFF
--- a/Packages/ClassCommentBrowser.pck.st
+++ b/Packages/ClassCommentBrowser.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2763] on 16 May 2016 at 6:02:36.088656 pm'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2778] on 30 May 2016 at 2:54:35.830404 pm'!
 'Description Browse class comments for classes with names such as "Pluggable," "Morphic," "Text," or "Morph" which appear in a hierarchical list.'!
-!provides: 'ClassCommentBrowser' 1 30!
+!provides: 'ClassCommentBrowser' 1 31!
 !classDefinition: #CommentGuide category: #ClassCommentBrowser!
 AbstractHierarchicalList subclass: #CommentGuide
 	instanceVariableNames: 'window rootNames root browser subList index key'
@@ -425,24 +425,27 @@ respondToKey: aChar
 	model indexOf: aChar.
 	listMorph update: #keySelection! !
 
-!CommentGuideWindow methodsFor: 'browsing' stamp: 'dhn 5/16/2016 17:54'!
+!CommentGuideWindow methodsFor: 'browsing' stamp: 'dhn 5/19/2016 11:19'!
 scrollToClass: aString
 	"Scroll to an entry for the class named aString"
-	| cat m1 m2 |
+	| cat m1 m2 str |
 	
+	"ensure that the first category which contains aString is expanded"
 	cat _ (model parseName: aString) first.
 	m1 _ listMorph findDeepSubmorphThat: [:ea | 
 		(ea respondsTo: #contents) and: [ea contents includesSubString: cat]] ifAbsent: [nil].
 	m1 ifNotNil: [m1 isExpanded ifFalse: [listMorph toggleExpandedState: m1]].
-		
+	
+	"select the class entry and scroll it into view"
+	str _  aString asString printString.
 	m2 _ listMorph findDeepSubmorphThat: [:ea | 
-		(ea respondsTo: #contents) and: [ea contents includesSubString: aString]] ifAbsent: [nil].
+		(ea respondsTo: #contents) and: [ea contents includesSubString: str]] ifAbsent: [nil].
 	m2 ifNotNil: [
 		listMorph 
 			setSelectedMorph: m2;
 			scrollSelectionIntoView]! !
 
-!CommentGuideWindow methodsFor: 'searching' stamp: 'dhn 5/16/2016 16:30'!
+!CommentGuideWindow methodsFor: 'searching' stamp: 'dhn 5/19/2016 11:26'!
 searchAllComments
 	"Search for a string in class comments of all classes"
 	| arg hits caption items n |
@@ -458,9 +461,10 @@ searchAllComments
 			items _ String streamContents: [:s | hits do: [:i | s nextPutAll: i asString; newLine]].
 			n _ (PopUpMenu labels: items lines: nil)
 				startUpWithCaption: caption.
-			self 
-				scrollToClass: (hits at: n);
-				showFind: (hits at: n) "show the comment of the selected class" ].
+			n > 0 ifTrue:[
+				self 
+					scrollToClass: (hits at: n);
+					showFind: (hits at: n) "show the comment of the selected class" ]].
 					
 	^ nil! !
 
@@ -527,11 +531,14 @@ searchIn: aCollection for: aString
 			ifTrue: [hits addLast: ea]].
 	^ hits! !
 
-!CommentGuideWindow methodsFor: 'browsing' stamp: 'dhn 5/16/2016 17:57'!
+!CommentGuideWindow methodsFor: 'browsing' stamp: 'dhn 5/19/2016 11:37'!
 showFind: aName
-	"Cause the class comment for aName to display"
+	"Cause the class comment for aName to display; answer the comment"
+	| cmt |
 
-	textMorph model actualContents: (model commentOf: aName)! !
+	cmt _ model commentOf: aName.
+	textMorph model actualContents: cmt.
+	^ cmt! !
 
 !CommentGuideWindow methodsFor: 'accessing' stamp: 'dhn 8/19/2015 19:47'!
 textMorph

--- a/Packages/TerseGuide.pck.st
+++ b/Packages/TerseGuide.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2781] on 31 May 2016 at 12:07:06.44249 pm'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2783] on 31 May 2016 at 4:20:45.807956 pm'!
 'Description Displays topics to aid the writing of Smalltalk code for Cuis.'!
-!provides: 'TerseGuide' 1 116!
+!provides: 'TerseGuide' 1 117!
 !classDefinition: #TerseGuideHelp category: #TerseGuide!
 Workspace subclass: #TerseGuideHelp
 	instanceVariableNames: 'topics topicListIndex selectedTopic topicList window textPane'
@@ -1233,7 +1233,7 @@ x sortBlock: sort.						"Specify how to sort the heap"
 x _ Heap withAll: #(11 32 19 21) sortBlock: sort.	"Create a new heap sorted according to a sortBlock"
 '! !
 
-!TerseGuideHelp class methodsFor: 'pages' stamp: 'dhn 2/23/2016 12:16'!
+!TerseGuideHelp class methodsFor: 'pages' stamp: 'dhn 5/31/2016 16:00'!
 internalStream
 	"Internal  Streams"
 	^
@@ -1272,6 +1272,14 @@ str nextPut: $,; space.						"newLine and tab are also possible"
 str nextPutAll: (Complex real: 4.7 imaginary: -2.2) printString.
 str nextPutAll: '' is the location of the pole.''.	"complete the formation"
 x _ str contents.								"to get the results"
+
+x _ String streamContents: [:str |		"a more compact way"
+	str 
+		nextPutAll: ''As of '';
+		nextPutAll: Date today asString;
+		nextPut: $,; space;
+		nextPutAll: (Complex real: 4.7 imaginary: -2.2) printString;
+		nextPutAll: '' is the location of the pole.''].
 
 '! !
 
@@ -2034,7 +2042,7 @@ y _ x asSet.											"convert to set collection"
 
 '! !
 
-!TerseGuideHelp class methodsFor: 'pages' stamp: 'dhn 2/22/2016 17:16'!
+!TerseGuideHelp class methodsFor: 'pages' stamp: 'dhn 5/31/2016 16:16'!
 string
 	"Strings"
 	^
@@ -2057,6 +2065,14 @@ x _ String with: $a with: $b with: $c with: $d.	"set up 4 elements at a time"
 x do: [:a | Transcript show: a printString; newLine].	"iterate over the string"
 b _ x allSatisfy: [:a | (a >= $a) & (a <= $z)].	"test if all elements meet condition"
 y _ x select: [:a | a > $a].					"return all elements that meet condition"
+
+x _ String streamContents: [:str |		"using a stream to form a string"
+	str 											"more efficient than concatenation"
+		nextPutAll: ''This string'';
+		nextPutAll: '' is formed today, '';
+		nextPutAll: Date today asString;
+		nextPutAll: '', without using concatenation.''].
+
 y _ x asSymbol.								"convert string to symbol"
 y _ x asArray.								"convert string to array"
 x _ ''ABCD'' asByteArray.					"convert string to byte array"


### PR DESCRIPTION
Corrects a bug where all class comments have been searched and a class such as TextStream has been selected but RWBinaryOrTextStream is scrolled into view. In other words the first class whose name contains the string "TextStream" is scrolled into view.

In TerseGuide, enhance Internal Streams and String topics to showcase #streamContents: .