### PR TITLE
updates to ClassCommentBrowser and TerseGuide packages

### DIFF
--- a/Packages/ClassCommentBrowser.pck.st
+++ b/Packages/ClassCommentBrowser.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2778] on 30 May 2016 at 2:54:35.830404 pm'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2820] on 15 June 2016 at 5:03:00.918822 pm'!
 'Description Browse class comments for classes with names such as "Pluggable," "Morphic," "Text," or "Morph" which appear in a hierarchical list.'!
-!provides: 'ClassCommentBrowser' 1 31!
+!provides: 'ClassCommentBrowser' 1 32!
 !classDefinition: #CommentGuide category: #ClassCommentBrowser!
 AbstractHierarchicalList subclass: #CommentGuide
 	instanceVariableNames: 'window rootNames root browser subList index key'
@@ -283,18 +283,14 @@ asString
 	"Answer the string for the hierarchical list category"
 	^ itemName! !
 
-!CommentGuideListMorph methodsFor: 'events-processing' stamp: 'dhn 11/5/2015 14:52'!
-update: aSymbol
-	"React to list selection via typed key"
+!CommentGuideListMorph methodsFor: 'events-processing' stamp: 'dhn 6/15/2016 16:56'!
+keySelection
+	"Scroll the hiearchical list based on a keystroke"
 	| i |
 	
-	super update: aSymbol.
-	aSymbol == #keySelection
-		ifTrue: [
-			model getCurrentSelection ifNil: [^self selectionIndex: 0].
-			i _ scroller submorphs findFirst: [:m | m contents == model getCurrentSelection itemName].
-			^ self selectionIndex: i]
-! !
+	model getCurrentSelection ifNil: [^self selectionIndex: 0].
+	i _ scroller submorphs findFirst: [:m | m contents == model getCurrentSelection itemName].
+	^ self selectionIndex: i! !
 
 !CommentGuideWindow methodsFor: 'browsing' stamp: 'dhn 11/5/2015 14:53'!
 browseClass
@@ -418,12 +414,12 @@ refreshListAfterDelay
 
 	self addAlarm: #refreshList after: 20 "milliseconds" ! !
 
-!CommentGuideWindow methodsFor: 'events' stamp: 'dhn 11/5/2015 11:33'!
+!CommentGuideWindow methodsFor: 'events' stamp: 'dhn 6/15/2016 16:56'!
 respondToKey: aChar
 	"Take action when a key is struck. The key value is aChar"
 
 	model indexOf: aChar.
-	listMorph update: #keySelection! !
+	listMorph keySelection! !
 
 !CommentGuideWindow methodsFor: 'browsing' stamp: 'dhn 5/19/2016 11:19'!
 scrollToClass: aString

--- a/Packages/ClassCommentBrowser.pck.st
+++ b/Packages/ClassCommentBrowser.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2820] on 15 June 2016 at 5:31:22.332822 pm'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2820] on 16 June 2016 at 1:19:29.860322 pm'!
 'Description Browse class comments for classes with names such as "Pluggable," "Morphic," "Text," or "Morph" which appear in a hierarchical list.'!
-!provides: 'ClassCommentBrowser' 1 33!
+!provides: 'ClassCommentBrowser' 1 34!
 !classDefinition: #CommentGuide category: #ClassCommentBrowser!
 AbstractHierarchicalList subclass: #CommentGuide
 	instanceVariableNames: 'window rootNames root browser subList index key'
@@ -333,7 +333,7 @@ browseVersions
 			VersionsBrowserWindow 
 				browseCommentOf: (Smalltalk at: model getCurrentSelection item asSymbol)]! !
 
-!CommentGuideWindow methodsFor: 'instance creation' stamp: 'jmv 3/28/2016 09:44'!
+!CommentGuideWindow methodsFor: 'instance creation' stamp: 'dhn 6/16/2016 13:08'!
 buildMorphicWindow
 	"Answer a window for the class comment browser"
 	| row |
@@ -346,6 +346,7 @@ buildMorphicWindow
 		menuGetter: #commentGuideMenu
 		keystrokeAction: #respondToKey:.
 	listMorph name: #Hierarchy.
+	self when: #getList send: #update: to: listMorph withArguments: #(#getList).
 	textMorph _ TextModelMorph textProvider: model.
 	textMorph 
 		name: 'Class Comment';
@@ -402,13 +403,13 @@ listMorph
 
 	^ listMorph! !
 
-!CommentGuideWindow methodsFor: 'instance creation' stamp: 'dhn 9/24/2015 09:35'!
+!CommentGuideWindow methodsFor: 'instance creation' stamp: 'dhn 6/16/2016 13:17'!
 refreshList
 	"Re-build the hierarchical list"
 	model 
 		noteNewSelection: nil;
 		rootNames: model setList.
-	listMorph update: #getList! !
+	self triggerEvent: #getList 	"needed when a class is added or deleted"! !
 
 !CommentGuideWindow methodsFor: 'instance creation' stamp: 'dhn 9/24/2015 08:45'!
 refreshListAfterDelay

--- a/Packages/ClassCommentBrowser.pck.st
+++ b/Packages/ClassCommentBrowser.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2820] on 15 June 2016 at 5:03:00.918822 pm'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2820] on 15 June 2016 at 5:31:22.332822 pm'!
 'Description Browse class comments for classes with names such as "Pluggable," "Morphic," "Text," or "Morph" which appear in a hierarchical list.'!
-!provides: 'ClassCommentBrowser' 1 32!
+!provides: 'ClassCommentBrowser' 1 33!
 !classDefinition: #CommentGuide category: #ClassCommentBrowser!
 AbstractHierarchicalList subclass: #CommentGuide
 	instanceVariableNames: 'window rootNames root browser subList index key'
@@ -66,8 +66,10 @@ Provide the wrapper for a list item in CommentGuideWindow.
 
 Removes the undesired cruft after the item name.!
 
-!CommentGuideListMorph commentStamp: 'dhn 11/5/2015 12:19' prior: 0!
-A list of terms and acronyms which occur in class names. Selection can be made by typed key, arrows, or clicks.!
+!CommentGuideListMorph commentStamp: 'dhn 6/15/2016 17:30' prior: 0!
+A list of terms and acronyms which occur in class names. Selection can be made by typed key, arrows, or clicks.
+
+This class enables access to the scroller, which is needed for selection by typed key.!
 
 !CommentGuideWindow commentStamp: 'dhn 1/28/2016 16:23' prior: 0!
 Show a window for browsing class comments based on class names which contain certain strings, such as:

--- a/Packages/TerseGuide.pck.st
+++ b/Packages/TerseGuide.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 4.2 of 25 July 2013 [latest update: #2783] on 31 May 2016 at 4:20:45.807956 pm'!
+'From Cuis 4.2 of 25 July 2013 [latest update: #2820] on 15 June 2016 at 7:06:16.030822 pm'!
 'Description Displays topics to aid the writing of Smalltalk code for Cuis.'!
-!provides: 'TerseGuide' 1 117!
+!provides: 'TerseGuide' 1 118!
 !classDefinition: #TerseGuideHelp category: #TerseGuide!
 Workspace subclass: #TerseGuideHelp
 	instanceVariableNames: 'topics topicListIndex selectedTopic topicList window textPane'
@@ -13,7 +13,7 @@ TerseGuideHelp class
 
 !classDefinition: #TerseGuideWindow category: #TerseGuide!
 WorkspaceWindow subclass: #TerseGuideWindow
-	instanceVariableNames: 'textModelM'
+	instanceVariableNames: 'textModelM list1'
 	classVariableNames: ''
 	poolDictionaries: ''
 	category: 'TerseGuide'!
@@ -49,13 +49,13 @@ initialize
 	topicList _ self class pages.
 ! !
 
-!TerseGuideHelp methodsFor: 'user interface support' stamp: 'dhn 10/18/2015 19:54'!
+!TerseGuideHelp methodsFor: 'user interface support' stamp: 'dhn 6/15/2016 18:29'!
 selectedTopic: aTopic
 	"Set the value of selectedTopic and set the contents of the text pane"
 	
 	selectedTopic _ aTopic.
 	textPane model actualContents: self updateTopicText.
-	self changed: #topicListIndex! !
+	self triggerEvent: #topicListIndex! !
 
 !TerseGuideHelp methodsFor: 'initialization' stamp: 'dhn 2/19/2016 20:35'!
 terseTopics
@@ -2230,10 +2230,10 @@ t explore.
 '
 ! !
 
-!TerseGuideWindow methodsFor: 'initialization' stamp: 'dhn 5/18/2016 12:08'!
+!TerseGuideWindow methodsFor: 'initialization' stamp: 'dhn 6/15/2016 19:03'!
 buildMorphicWindow
 	"Define the window layout for Terse Guide"
-	| list1 row |
+	| row |
 	
 	list1 _ (PluggableListMorph
 				model: model
@@ -2248,6 +2248,7 @@ buildMorphicWindow
 	textModelM
 		askBeforeDiscardingEdits: false;
 		name: 'Work Space'.
+	model when: #topicListIndex send: #update: to: list1 withArguments: #(#topicListIndex).
 	row _ LayoutMorph newRow.
 	row
 		name: #Row;


### PR DESCRIPTION
In ClassCommentBrowser, the #update: method is avoided and eliminated. Also, instead of sending #update: to the ListMorph, #triggerEvent: and #when:send:to:withArguments: are used. QUESTION: is this an appropriate change? It anticipates that at some point the #update: method will be removed from super.

In TerseGuide, #triggerEvent: and #when:send:to:withArguments: replace the dependency mechanism.