### PR TITLE
Morph hover events - a missing feature found in many desktop and web …

### DIFF
--- a/CoreUpdates/3123-UpdatingStringMorph-Squeak-compatibility-PhilBellalouna-2017Jul15-22h07m-pb.1.cs.st
+++ b/CoreUpdates/3123-UpdatingStringMorph-Squeak-compatibility-PhilBellalouna-2017Jul15-22h07m-pb.1.cs.st
@@ -1,0 +1,7 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3121] on 15 July 2017 at 10:07:51 pm'!
+
+!UpdatingStringMorph methodsFor: 'stepping' stamp: 'pb 7/15/2017 22:07:40'!
+stepAt: millisecondSinceLast
+
+	self contents: (target perform: getSelector) asString! !
+

--- a/CoreUpdates/3124-PluggableButtonMorph-initial-extent-PhilBellalouna-2017Jul15-22h29m-pb.2.cs.st
+++ b/CoreUpdates/3124-PluggableButtonMorph-initial-extent-PhilBellalouna-2017Jul15-22h29m-pb.2.cs.st
@@ -1,0 +1,217 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3121] on 15 July 2017 at 11:19:17 pm'!
+
+!PluggableButtonMorph methodsFor: 'as yet unclassified' stamp: 'pb 7/15/2017 23:15:35'!
+morphExtent
+	"Use extent if it has already been manually set, otherwise try to set it by computing from the label text and font, otherwise try using the icon extent, or finally fall back to the default value."
+	^ extent ifNil: [
+		extent := (self fontToUse notNil and: [ label notNil ])
+			ifTrue: [ "Add a bit of padding"
+				(self fontToUse widthOfString: label) + 10 @ (self fontToUse height + 10) ]
+			ifFalse: [
+				icon
+					ifNil: [ `20@15` ]
+					ifNotNil: [ icon extent ]]].! !
+
+
+!RectangleLikeMorph methodsFor: 'geometry' stamp: 'pb 7/15/2017 22:34:12'!
+morphHeight
+
+"Ensure everybody wants our coordinates!!"
+	self flag: #jmvVer2.
+	^ self morphExtent y! !
+
+!RectangleLikeMorph methodsFor: 'geometry' stamp: 'pb 7/15/2017 22:34:52'!
+morphPosition: newPos extent: newExtent
+	"Change the position of this morph. Argument is in owner's coordinates."
+
+	| oldBoundsInWorld someChange |
+
+	"Ask for the old bounds before updating them, but ask for repair only if extent or position has really changed."
+	oldBoundsInWorld _ self morphBoundsInWorld.
+	someChange _ false.
+	(location isTranslation: newPos) ifFalse: [
+		location _ location withTranslation: newPos.
+		someChange _ true ].
+
+	self morphExtent = newExtent ifFalse: [
+		(self privateExtent: newExtent) ifTrue: [
+			someChange _ true ]].
+
+	someChange ifTrue: [
+		"Ask for the old bounds before updating them, but ask for repair only if extent or position has really changed."
+		oldBoundsInWorld ifNotNil: [
+			self invalidateDisplayRect: oldBoundsInWorld from: nil ].
+		self someSubmorphPositionOrExtentChanged.
+		owner ifNotNil: [ owner someSubmorphPositionOrExtentChanged ].
+		self redrawNeeded ]! !
+
+!RectangleLikeMorph methodsFor: 'geometry' stamp: 'pb 7/15/2017 22:34:20'!
+morphWidth
+
+"Ensure everybody wants our coordinates!!"
+	self flag: #jmvVer2.
+	^ self morphExtent x! !
+
+
+!PluggableButtonMorph methodsFor: 'drawing' stamp: 'pb 7/15/2017 22:40:30'!
+draw3DLookOn: aCanvas
+
+	| borderStyleSymbol c |
+	borderStyleSymbol _ self isPressed ifFalse: [ #raised ] ifTrue: [ #inset ].
+	c _ color.
+	self mouseIsOver ifTrue: [ c _ c  lighter ].
+	aCanvas
+		fillRectangle: (`0@0` extent: self morphExtent)
+		color: c
+		borderWidth: borderWidth
+		borderStyleSymbol: borderStyleSymbol
+		baseColorForBorder: c.
+
+	self drawRegularLabelOn: aCanvas! !
+
+!PluggableButtonMorph methodsFor: 'drawing' stamp: 'pb 7/15/2017 22:40:17'!
+drawEmbossedLabelOn: aCanvas
+
+	| availableW center colorForLabel f l labelMargin targetSize w x y |
+	label ifNotNil: [
+		colorForLabel _ Theme current buttonLabel.
+		self isPressed
+			ifFalse: [
+				self mouseIsOver
+					ifFalse: [ colorForLabel _ colorForLabel adjustSaturation: -0.10 brightness: 0.10 ]]
+			ifTrue: [ colorForLabel _ colorForLabel adjustSaturation: 0.0 brightness: -0.07 ].
+		f _ self fontToUse.
+		center _ self morphExtent // 2.
+		labelMargin _ 3.
+		w _ f widthOfString: label.
+		availableW _ self morphExtent x - labelMargin - labelMargin.
+		availableW >= w
+			ifTrue: [
+				l _ label ]
+			ifFalse: [
+				x _ labelMargin.
+				targetSize _ label size * availableW // w.
+				l _ label squeezedTo: targetSize.
+				(f widthOfString: l) > availableW ifTrue: [
+					targetSize _ targetSize - 1.
+					l _ label squeezedTo: targetSize ]].
+		
+		w _ f widthOfString: l.
+		x _ center x - (w // 2).
+		y _ center y - (f height // 2).
+		aCanvas
+			drawString: l
+			at: x@y
+			font: f
+			color: colorForLabel
+			embossed: true ]! !
+
+!PluggableButtonMorph methodsFor: 'drawing' stamp: 'pb 7/15/2017 22:39:57'!
+drawRegularLabelOn: aCanvas
+
+	| w f center x y  availableW l labelMargin |
+
+	f _ self fontToUse.
+	center _ self morphExtent // 2.
+
+	label ifNotNil: [
+		labelMargin _ 4.
+		w _ f widthOfString: label.
+		availableW _ self morphExtent x - labelMargin - labelMargin - 1.
+		availableW >= w
+			ifTrue: [
+				x _ center x - (w // 2).
+				l _ label ]
+			ifFalse: [
+				x _ labelMargin.
+				l _ label squeezedTo: (label size * availableW / w) rounded ].
+		y _ center y - (f height // 2).
+		self isPressed ifTrue: [
+			x _ x + 1.
+			y _ y + 1 ].
+		aCanvas
+			drawString: l
+			at: x@y
+			font: f
+			color: Theme current buttonLabel ]! !
+
+!PluggableButtonMorph methodsFor: 'drawing' stamp: 'pb 7/15/2017 22:39:34'!
+drawRoundGradientLookOn: aCanvas
+	| r colorForButton rect bottomFactor topFactor |
+
+	self isPressed
+		ifFalse: [
+			topFactor _ Theme current buttonGradientTopFactor.
+			bottomFactor _ Theme current buttonGradientBottomFactor.
+			self mouseIsOver
+				ifTrue: [	
+					colorForButton _ Color h: color hue s: color saturation * 1.3 v: color brightness * 0.9 ]
+				ifFalse: [
+					colorForButton _ color ]]
+		ifTrue: [
+			topFactor _ Theme current buttonGradientBottomFactor.
+			bottomFactor _ Theme current buttonGradientTopFactor.
+			colorForButton _ color adjustSaturation: 0.1 brightness: -0.1 ].
+
+	colorForButton ifNotNil: [
+		r _ Theme current roundedButtonRadius.
+		Theme current useButtonGradient
+			ifTrue: [
+				rect _ (`0@0` extent: self morphExtent) insetBy: `1@3`.
+				aCanvas
+					roundRect: rect
+					color: colorForButton
+					radius: r
+					gradientTop: topFactor
+					gradientBottom: bottomFactor
+					gradientHeight: Theme current buttonGradientHeight ]
+			ifFalse: [
+				rect _ (`0@0` extent: self morphExtent) insetBy: `1@3`.
+				aCanvas roundRect: rect color: colorForButton radius: r ]
+		].
+
+	Theme current embossedButtonLabels
+		ifTrue: [ self drawEmbossedLabelOn: aCanvas ]
+		ifFalse: [ self drawRegularLabelOn: aCanvas ]! !
+
+!PluggableButtonMorph methodsFor: 'initialization' stamp: 'pb 7/15/2017 22:36:46'!
+initialize
+	"initialize the state of the receiver"
+	super initialize.
+
+	roundButtonStyle := nil.	"nil: honor Theme. true: draw as round button. false: draw as classic 3d border square button"
+	model := nil.
+	getStateSelector := nil.
+	actionSelector := nil.
+	isPressed := false.
+	mouseIsOver := false.
+	actWhen := #buttonUp.
+	"We are overriding any value populated in extent by our superclass with nil so we know to perform the inital morph extent calculation"
+	extent := nil! !
+
+!PluggableButtonMorph methodsFor: 'private' stamp: 'pb 7/15/2017 22:36:28'!
+magnifiedIcon
+	| factor magnifiedExtent w h |
+
+	icon ifNil: [ ^nil ].
+	magnifiedIcon ifNil: [
+		magnifiedIcon := icon.
+		w := icon width.
+		h := icon height.
+		w*h = 0 ifFalse: [
+			factor _ 1.0 * self morphExtent x / w min: 1.0 * self morphExtent y / h.
+			(factor < 1 or: [ factor > 1.7 and: [self isRoundButton]]) ifTrue: [
+				magnifiedExtent := (icon extent * factor) rounded.
+				magnifiedIcon := icon magnifyTo: magnifiedExtent ]]].
+	^magnifiedIcon! !
+
+!PluggableButtonMorph methodsFor: 'geometry testing' stamp: 'pb 7/15/2017 22:38:44'!
+morphContainsPoint: aLocalPoint
+
+	| iconOrigin |
+	((`0@0` extent: self morphExtent) containsPoint: aLocalPoint) ifFalse: [ ^false ].
+	^ self isOrthoRectangularMorph or: [
+		magnifiedIcon isNil or: [
+			iconOrigin := self morphExtent - magnifiedIcon extent // 2.
+			(magnifiedIcon isTransparentAt: (aLocalPoint - iconOrigin) rounded) not ]]! !
+

--- a/CoreUpdates/3125-Morph-hovering-PhilBellalouna-2017Jul16-15h00m-pb.1.cs.st
+++ b/CoreUpdates/3125-Morph-hovering-PhilBellalouna-2017Jul16-15h00m-pb.1.cs.st
@@ -1,0 +1,36 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3121] on 16 July 2017 at 3:33:18 pm'!
+
+!Morph methodsFor: 'events' stamp: 'pb 7/16/2017 15:06:53'!
+mouseHover: aMouseMoveEvent localPosition: localEventPosition
+	"Handle a mouse move event.
+	This message will only be sent to Morphs that answer true to #handlesMouseHover for events that have not been previously handled.
+	We can query aMouseMoveEvent to know about pressed mouse buttons."
+	"Allow instances to dynamically use properties for handling common events."
+	self
+		valueOfProperty: #mouseHover:localPosition:
+		ifPresentDo: [ :handler |
+			handler
+				value: aMouseMoveEvent
+				value: localEventPosition ].! !
+
+!Morph methodsFor: 'event handling testing' stamp: 'pb 7/16/2017 15:00:51'!
+handlesMouseHover
+	"Do I want to receive unhandled mouseMove events when the button is up and the hand is empty?  The default response is false."
+	"Use a property test to allow individual instances to specify this."
+	^ self hasProperty: #handlesMouseHover.! !
+
+
+!Morph methodsFor: 'events-processing' stamp: 'pb 7/16/2017 15:31:38'!
+processMouseOver: aMouseEvent localPosition: localEventPosition
+	"System level event handling."
+	 self hasMouseFocus ifTrue: [
+		"Got this directly through #handleFocusEvent: so check explicitly"
+		(self containsPoint: localEventPosition event: aMouseEvent) ifFalse: [
+			^self ]].
+	aMouseEvent hand noticeMouseOver: self event: aMouseEvent.
+	"Open question: should any unhandled mouse move events be filtered out? (i.e. should mouseHover:localPosition: be called when a mouse button is pressed but the morph doesn't have mouse button handlers?  Essentially, what are the limits of what is considered 'hovering'?"
+	(self handlesMouseHover and: [aMouseEvent wasHandled not]) ifTrue: [
+		self
+			mouseHover: aMouseEvent
+			localPosition: localEventPosition ].! !
+

--- a/Packages/BouncingAtoms.pck.st
+++ b/Packages/BouncingAtoms.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 5.0 of 7 November 2016 [latest update: #3020] on 2 January 2017 at 9:11:04 am'!
+'From Cuis 5.0 of 7 November 2016 [latest update: #3125] on 16 July 2017 at 4:18:03 pm'!
 'Description A port of Bouncing Atoms with the atoms in a SystemWindow. A pop-up menu enables selection of options, including an active plot of infection history, also in a SystemWindow.'!
-!provides: 'BouncingAtoms' 1 30!
+!provides: 'BouncingAtoms' 1 31!
 !requires: 'Morphic-Widgets-Extras' 1 0 nil!
 !classDefinition: #AtomMorph category: #BouncingAtoms!
 EllipseMorph subclass: #AtomMorph
@@ -24,7 +24,7 @@ HeaterCoolerAtom class
 
 !classDefinition: #InfectionGraph category: #BouncingAtoms!
 FunctionGraphMorph subclass: #InfectionGraph
-	instanceVariableNames: 'data points yScaleFactor startTime deltaT ticN tics yFactor xFactor resumed'
+	instanceVariableNames: 'data points yScaleFactor startTime deltaT ticN tics yFactor xFactor resumed hoverPoint'
 	classVariableNames: ''
 	poolDictionaries: ''
 	category: 'BouncingAtoms'!
@@ -266,7 +266,7 @@ data: aCollection
 	data _ aCollection
 ! !
 
-!InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/12/2016 12:28'!
+!InfectionGraph methodsFor: 'drawing' stamp: 'pb 7/16/2017 16:08:49'!
 drawOn: aCanvas
 	| fully |
 	fully _ 10 raisedTo: yMax log asInteger.
@@ -276,16 +276,41 @@ drawOn: aCanvas
 	aCanvas line: (self toMorphic: 0@fully) to: (self toMorphic: xMax@fully) width: 2 color: Color lightRed.
 
 	points ifNotNil: [
-		1 to: points size - 1 do: [:n | | p |
+		1 to: points size - 1 do: [:n | | p fromPoint toPoint |
+			fromPoint := (self toMorphic: (p _ points at: n)).
+			toPoint := (self toMorphic: (points at: n + 1)).
 			aCanvas 	"continue the graph"
-				line: (self toMorphic: (p _ points at: n)) 	"from point"
-				to: (self toMorphic: (points at: n + 1)) 	"to point"
+				line: fromPoint 	"from point"
+				to: toPoint 	"to point"
 				width: 2 color: Color black.
 			(self tics includes: n) ifTrue: [
 				aCanvas 	"plot the tic"
 					line: (self toMorphic: (p x) @ 0) 
 					to: (self toMorphic: (p x) @ (self class ticLength)) 
-					width: 2 color: Color lightGray]]]! !
+					width: 2 color: Color lightGray].
+			hoverPoint ifNotNil: [|font|
+				((hoverPoint x  >= fromPoint x) and: [hoverPoint x <= toPoint x])  ifTrue: [
+					font := StrikeFont default.
+					aCanvas
+						line:  hoverPoint x@(self yToMorphic: yMin)
+						to: hoverPoint x@fromPoint y
+						width: 2
+						color: Color green.
+					aCanvas
+						drawString: (p x truncateTo: 0.1) asString
+						at: hoverPoint x@(fromPoint y- font height )
+						font: font
+						color: Color green
+						embossed: true]]]]! !
+
+!InfectionGraph methodsFor: 'as yet unclassified' stamp: 'pb 7/16/2017 15:35:43'!
+handlesMouseHover
+	^ true! !
+
+!InfectionGraph methodsFor: 'as yet unclassified' stamp: 'pb 7/16/2017 15:44:18'!
+mouseHover: event localPosition: localPosition
+	hoverPoint := localPosition.
+	self redrawNeeded ! !
 
 !InfectionGraph methodsFor: 'drawing' stamp: 'dhn 5/23/2015 11:50'!
 normalize: aCollection


### PR DESCRIPTION
…applications.  This helps in providing liveness to Morphs with complex internal structure. BouncingAtomsMorph has been updated to provide an example use case: when you open the infection history graph and mouse over it, it will display an indicator and the numeric value at the y axis on the graph for the point hovered over.

PluggableButtonMorph - Calculate a sensible default extent for PluggableButtonMorph which would allow for removal of hard-coding widths in scenarios where proportional width buttons are desired.  It also makes buttons more readily usable by default without layouts and/or hard coding extents where that is desired.  I've tested on a wide variety of existing morphs and the only issues I ran into (and fixed) were methods in the Button class hierarchy accessing extent directly rather than via self morphExtent (which has resolved every issue I ran into while testing this)  Note that the core of the change is trivial: #initialize and #morphExtent.

Some example scenarios considered:
PluggableButtonMorph new label: 'Test'; openInWorld.
PluggableButtonMorph new label: 'Test' font: (AbstractFont familyName: 'DejaVu' aroundPointSize: 22); openInWorld.
PluggableButtonMorph new openInWorld.
(PluggableButtonMorph new)
		icon: Theme current closeIcon;
		iconName: #drawCloseIcon;
		setBalloonText: 'close this window';
		openInWorld.

UpdatingStringMorph - A minor tweak to coerce to String as needed.  Some older Squeak code assumes the more liberal coercion from number->string and it seems like a good idea in general for this Morph.