### PR TITLE
Misc tweaks and 2nd attempt at PluggableButtonMorph (longer comment f…

### DIFF
--- a/CoreUpdates/3131-Debugger-ensure-focus-released-PhilBellalouna-2017Jul23-00h47m-pb.1.cs.st
+++ b/CoreUpdates/3131-Debugger-ensure-focus-released-PhilBellalouna-2017Jul23-00h47m-pb.1.cs.st
@@ -1,0 +1,34 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3128] on 23 July 2017 at 12:48:38 am'!
+
+!Debugger class methodsFor: 'opening' stamp: 'pb 7/23/2017 00:47:24'!
+openOn: process context: context label: title fullView: bool
+	"Open a notifier in response to an error, halt, or notify. A notifier view just shows a short view of the sender stack and provides a menu that lets the user open a full debugger."
+
+	| w |
+	Preferences logDebuggerStackToFile ifTrue: [
+		Smalltalk logError: title inContext: context to: 'CuisDebug.log'].
+	w _ ProjectX newProcessIfUIX: process.
+	"schedule debugger in deferred UI message to address redraw
+	problems after opening a debugger e.g. from the testrunner."
+	WorldState addDeferredUIMessage: [ 
+		[	| debugger |
+			"In case an error in Morphic code got us here, ensure mouse focus has been released"
+			true runningWorld activeHand releaseMouseFocus.
+			debugger _ self new process: process context: context.
+			debugger interruptedProcessUI: w.
+			bool
+				ifTrue: [debugger openFullMorphicLabel: title]
+				ifFalse: [PreDebugWindow open: debugger label: title message: nil]
+		] on: UnhandledError do: [ :exOuter |
+			| errorDescription |
+			errorDescription _ 'Error while trying to open Debugger', String newLineString,
+				'Orginal error: ', title asString, '.', String newLineString,
+				'	Debugger error: ', 
+				([exOuter description]
+					on: UnhandledError
+					do: [:exInner | exInner return: 'a ', exInner class printString]), ':'.
+			self primitiveError: errorDescription
+		]
+	].
+	process suspend! !
+

--- a/CoreUpdates/3132-CodePackageWindow-layout-tweak-PhilBellalouna-2017Jul23-00h53m-pb.1.cs.st
+++ b/CoreUpdates/3132-CodePackageWindow-layout-tweak-PhilBellalouna-2017Jul23-00h53m-pb.1.cs.st
@@ -1,0 +1,71 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3128] on 23 July 2017 at 1:07:52 am'!
+
+!CodePackageListWindow methodsFor: 'GUI building' stamp: 'pb 7/23/2017 00:53:45'!
+buildMorphicWindow
+	" 
+	CodePackageListWindow open: CodePackageList new
+	"
+	| dirtyFlags names fileNames upperRow  description summary backColor labelBackground textHeigth |
+	backColor := self textBackgroundColor.	
+	labelBackground := Theme current background.
+	textHeigth := AbstractFont default height.
+	
+	dirtyFlags := PluggableListMorph
+		model: model 
+		listGetter: #packageDirtyFlags
+		indexGetter: #selectionIndex
+		indexSetter: #selectionIndex:.
+	dirtyFlags color: backColor.
+	dirtyFlags := LayoutMorph newColumn
+		color: labelBackground;
+		addMorph: (RectangleLikeMorph new color: Color transparent) fixedHeight: 4;
+		addMorph: (StringMorph new contents: ' Unsaved?') fixedHeight: textHeigth;
+		addMorphUseAll: dirtyFlags.
+
+	names := PluggableListMorph
+		model: model 
+		listGetter: #packageNames
+		indexGetter: #selectionIndex
+		indexSetter: #selectionIndex:.
+	names color: backColor.
+	names := LayoutMorph newColumn
+		color: labelBackground;
+		addMorph: (RectangleLikeMorph new color: Color transparent) fixedHeight: 4;
+		addMorph: (StringMorph new contents: ' Package Name') fixedHeight: textHeigth;
+		addMorphUseAll: names.
+
+	fileNames := PluggableListMorph
+		model: model 
+		listGetter: #packageFullNames
+		indexGetter: #selectionIndex
+		indexSetter: #selectionIndex:.
+	fileNames color: backColor.
+	fileNames := LayoutMorph newColumn
+		color: labelBackground;
+		addMorph: (RectangleLikeMorph new color: Color transparent) fixedHeight: 4;
+		addMorph: (StringMorph new contents: ' File Name') fixedHeight: textHeigth;
+		addMorphUseAll: fileNames.
+
+	upperRow := LayoutMorph newRow.
+	upperRow
+		addMorph: dirtyFlags proportionalWidth: 0.13;
+		addAdjusterAndMorph: names proportionalWidth: 0.27;
+		addAdjusterAndMorph: fileNames proportionalWidth: 0.6.
+		
+	description := TextModelMorph
+		textProvider: model
+		textGetter: #description 
+		textSetter: #description:.
+
+	summary := TextModelMorph
+		textProvider: model
+		textGetter: #summary.
+
+	self layoutMorph
+		addMorph: upperRow proportionalHeight: 0.6;
+		addAdjusterAndMorph: self buildButtonPane fixedHeight: Theme current buttonPaneHeight;
+		addAdjusterAndMorph: summary fixedHeight: 60;
+		addAdjusterAndMorph: description proportionalHeight: 0.25;
+		addAdjusterAndMorph: self buildRequirementsPane proportionalHeight: 0.15.
+	self setLabel: 'Installed Packages'! !
+

--- a/CoreUpdates/3133-category-cleanup-PhilBellalouna-2017Jul23-13h39m-pb.1.cs.st
+++ b/CoreUpdates/3133-category-cleanup-PhilBellalouna-2017Jul23-13h39m-pb.1.cs.st
@@ -1,0 +1,59 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3128] on 23 July 2017 at 1:47:54 pm'!
+
+!PluggableButtonMorph reorganize!
+('accessing' actWhen: action: actionSelector adoptWidgetsColor: icon: iconName: label: label:font: performAction roundButtonStyle:)
+('drawing' draw3DLookOn: drawEmbossedLabelOn: drawOn: drawRegularLabelOn: drawRoundGradientLookOn: fontToUse iconColor)
+('events' mouseButton1Down:localPosition: mouseButton1Up:localPosition: mouseEnter: mouseLeave: mouseStillDown)
+('event handling testing' handlesMouseDown: handlesMouseOver: handlesMouseStillDown:)
+('event handling' mouseStillDownStepRate)
+('initialization' defaultBorderWidth initialize model: model:stateGetter:action:label:)
+('updating' update:)
+('private' getModelState iconName magnifiedIcon)
+('testing' is: isPressed isRoundButton mouseIsOver)
+('geometry' morphExtent privateExtent:)
+('geometry testing' isOrthoRectangularMorph morphContainsPoint:)
+('scrollbar button' updateDownButtonImage updateLeftButtonImage updateRightButtonImage updateUpButtonImage)
+!
+
+
+!PluggableListMorph reorganize!
+('accessing' rowAtLocation:)
+('drawing' drawOn:)
+('events' doubleClick:localPosition: keyStroke: mouseButton1Down:localPosition: mouseButton1Up:localPosition: mouseEnter:)
+('event handling testing' handlesKeyboard)
+('event handling' keyboardFocusChange: mouseButton2Activity)
+('events-processing' processMouseMove:localPosition:)
+('geometry' fontPreferenceChanged scrollDeltaHeight scrollDeltaWidth)
+('initialization' autoDeselect: doubleClickSelector: font font: initForKeystrokes initialize innerMorphClass listItemHeight model:listGetter:indexGetter:indexSetter:mainView:menuGetter:keystrokeAction: textColor)
+('keyboard navigation' arrowKey:)
+('menu' getMenu)
+('menus' addCustomMenuItems:hand: copyListToClipboard copySelectionToClipboard)
+('model access' changeModelSelection: getCurrentSelectionIndex getList getListItem: getListSize itemSelectedAmongMultiple: keyboardSearch: keystrokeAction:)
+('selection' getListSelector maximumSelection minimumSelection numSelectionsInView scrollSelectionIntoView selection selection: selectionIndex selectionIndex:)
+('updating' update: updateList verifyContents)
+('testing' is:)
+('private' listMorph)
+!
+
+
+!InnerListMorph reorganize!
+('initialization' initialize)
+('list management' drawBoundsForRow: drawYForRow: highlightedRow: listChanged rowAtLocation: selectedRow selectedRow:)
+('drawing' bottomVisibleRowForCanvas: colorForRow: draw:atRow:on: drawBackgroundForMulti:on: drawHighlightOn: drawOn: drawSelectionOn: font font: topVisibleRowForCanvas:)
+('list access' getListItem: getListSize item:)
+('scroll range' desiredWidth widthToDisplayItem:)
+('private' noSelection)
+('geometry' adjustExtent fontPreferenceChanged)
+!
+
+
+!ResizeMorph reorganize!
+('as yet unclassified' selectTo: selectionRectangle: toGridPoint: updateOutlineMorph)
+('drawing' drawGridOn: drawOn:)
+('event handling testing' handlesMouseDown:)
+('initialization' initialize)
+('events' mouseButton1Down:localPosition: mouseButton1Up:localPosition: mouseMove:localPosition:)
+('printing' printOn:)
+('accessing' action: grid:)
+!
+

--- a/CoreUpdates/3134-PluggableButtonMorph-morphExtent-take2-PhilBellalouna-2017Jul23-15h08m-pb.1.cs.st
+++ b/CoreUpdates/3134-PluggableButtonMorph-morphExtent-take2-PhilBellalouna-2017Jul23-15h08m-pb.1.cs.st
@@ -1,0 +1,57 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3130] on 23 July 2017 at 4:39:28 pm'!
+
+!Form methodsFor: 'scaling, rotation' stamp: 'pb 7/23/2017 15:54:09'!
+scalePreservingAspectRatioTo: extent
+	"Answer a Form created as a scaling of the receiver."
+	extent x * extent y = 0
+		ifTrue: [ ^ self ]
+		ifFalse: [ | factor magnifiedExtent |
+			factor _ 1.0 * extent x / self width min: 1.0 * extent y / self height.
+					magnifiedExtent _ self extent * factor.
+					^ self magnifyTo: magnifiedExtent ].! !
+
+
+!PluggableButtonMorph methodsFor: 'private' stamp: 'pb 7/23/2017 16:38:09'!
+magnifiedIcon
+	icon ifNil: [ ^ nil ].
+	magnifiedIcon ifNil: [ | w h factor |
+		magnifiedIcon := icon.
+		w _ icon width.
+		h _ icon height.
+		w * h = 0 ifFalse: [
+			factor _ 1.0 * self morphExtent x / w min: 1.0 * self morphExtent y / h.
+			(factor < 1 or: [
+				factor > 1.7 and: [ self isRoundButton ]]) ifTrue: [ magnifiedIcon _ icon scalePreservingAspectRatioTo: self morphExtent ]]].
+	^ magnifiedIcon.! !
+
+!PluggableButtonMorph methodsFor: 'as yet unclassified' stamp: 'pb 7/23/2017 15:08:40'!
+morphExtent
+	"Use extent if it has already been manually set, otherwise try to set it by computing from the label text and font, otherwise try using the icon extent, or finally fall back to the default value."
+	^ extent ifNil: [
+		extent _ (self fontToUse notNil and: [ label notNil ])
+			ifTrue: [ "Add a bit of padding"
+				(self fontToUse widthOfString: label) + 10 @ (self fontToUse height + 10) ]
+			ifFalse: [
+				icon
+					ifNil: [ `20@15` ]
+					ifNotNil: [ icon extent ]]].! !
+
+
+!TaskbarMorph methodsFor: 'services' stamp: 'pb 7/23/2017 15:54:49'!
+addButtonFor: aMorph
+
+	| button |
+	aMorph == self ifFalse: [
+		button _ PluggableButtonMorph
+			model: aMorph
+			stateGetter: nil
+			action: #toggleCollapseOrShow.
+		button
+			color: self color;
+			icon: ((aMorph imageForm: 32) scalePreservingAspectRatioTo: `128@128`);
+			setBalloonText: aMorph label.
+		button icon: button magnifiedIcon.
+		viewBox
+			addMorph: button
+			fixedWidth: self defaultHeight ]! !
+

--- a/CoreUpdates/3135-menu-item-marker-PhilBellalouna-2017Jul25-21h21m-pb.1.cs.st
+++ b/CoreUpdates/3135-menu-item-marker-PhilBellalouna-2017Jul25-21h21m-pb.1.cs.st
@@ -1,0 +1,203 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3130] on 25 July 2017 at 9:35:35 pm'!
+
+!Boolean methodsFor: 'converting' stamp: 'pb 7/25/2017 21:35:09'!
+asMenuItemMarkerString
+	"If this markup is present in a menu item label, an on/off indicator will be displayed"
+	^ self
+		ifTrue: [ '<on>' ]
+		ifFalse: [ '<off>' ].! !
+
+
+!CodeProvider methodsFor: 'diffs' stamp: 'pb 7/25/2017 21:24:16'!
+showingLineDiffsString
+	"Answer a string representing whether I'm showing regular diffs"
+	^ self showingLineDiffs asMenuItemMarkerString , 'lineDiffs'.! !
+
+!CodeProvider methodsFor: 'diffs' stamp: 'pb 7/25/2017 21:24:39'!
+showingPrettyLineDiffsString
+	"Answer a string representing whether I'm showing pretty diffs"
+	^ self showingPrettyLineDiffs asMenuItemMarkerString , 'linePrettyDiffs'.! !
+
+!CodeProvider methodsFor: 'diffs' stamp: 'pb 7/25/2017 21:24:50'!
+showingPrettyWordDiffsString
+	"Answer a string representing whether I'm showing pretty diffs"
+	^ self showingPrettyWordDiffs asMenuItemMarkerString , 'wordPrettyDiffs'.! !
+
+!CodeProvider methodsFor: 'diffs' stamp: 'pb 7/25/2017 21:24:58'!
+showingWordDiffsString
+	"Answer a string representing whether I'm showing regular diffs"
+	^ self showingWordDiffs asMenuItemMarkerString , 'wordDiffs'.! !
+
+!CodeProvider methodsFor: 'what to show' stamp: 'pb 7/25/2017 21:23:37'!
+prettyPrintString
+	"Answer whether the receiver is showing pretty-print"
+	^ (self contentsSymbol == #prettyPrint) asMenuItemMarkerString , 'prettyPrint'.! !
+
+!CodeProvider methodsFor: 'what to show' stamp: 'pb 7/25/2017 21:23:33'!
+showingByteCodesString
+	"Answer whether the receiver is showing bytecodes"
+	^ self showingByteCodes asMenuItemMarkerString , 'byteCodes'.! !
+
+!CodeProvider methodsFor: 'what to show' stamp: 'pb 7/25/2017 21:23:51'!
+showingDecompileString
+	"Answer a string characerizing whether decompilation is showing"
+	^ self showingDecompile asMenuItemMarkerString , 'decompile'.! !
+
+!CodeProvider methodsFor: 'what to show' stamp: 'pb 7/25/2017 21:24:04'!
+showingDocumentationString
+	"Answer a string characerizing whether documentation is showing"
+	^ self showingDocumentation asMenuItemMarkerString , 'documentation'.! !
+
+!CodeProvider methodsFor: 'what to show' stamp: 'pb 7/25/2017 21:24:29'!
+showingPlainSourceString
+	"Answer a string telling whether the receiver is showing plain source"
+	^ self showingPlainSource asMenuItemMarkerString , 'source'.! !
+
+
+!TextEditor methodsFor: 'attributes' stamp: 'pb 7/25/2017 21:28:16'!
+changeEmphasisOrAlignment
+	"This is a user command, and generates undo"
+	| menuStrings aList reply code align menuList startIndex attribute |
+	startIndex _ self startIndex.
+	aList _ #(#normal #bold #italic #underlined #struckThrough #leftFlush #centered #rightFlush #justified ).
+	align _ model actualContents alignmentAt: startIndex.
+	code _ model actualContents emphasisAt: startIndex.
+	menuList _ WriteStream on: Array new.
+	menuList nextPut: code isZero asMenuItemMarkerString , 'normal'.
+	menuList nextPutAll:
+		(#(#bold #italic #underlined #struckThrough #superscript #subscript #withST80Glyphs ) collect: [ :emph |
+			(code anyMask: (TextEmphasis perform: emph) emphasisCode) asMenuItemMarkerString , emph asString ]).
+	menuList nextPutAll:
+		(#(#leftFlush #centered #rightFlush #justified ) withIndexCollect: [ :type :i |
+			(align = (i - 1)) asMenuItemMarkerString 
+				 , type asString 
+				]).
+	menuStrings _ menuList contents.
+	aList _ #(#normal #bold #italic #underlined #struckThrough #superscript #subscript #withST80Glyphs #leftFlush #centered #rightFlush #justified ).
+	reply _ (SelectionMenu
+		labelList: menuStrings
+		lines: #(1 8 )
+		selections: aList) startUpWithoutKeyboard.
+	reply ifNotNil: [
+		(#(#leftFlush #centered #rightFlush #justified ) includes: reply)
+			ifTrue: [ attribute _ TextAlignment perform: reply ]
+			ifFalse: [ attribute _ TextEmphasis perform: reply ].
+		((menuStrings at: (aList indexOf: reply)) beginsWith: '<on>')
+			ifTrue: [ self unapplyAttributes: {attribute} ]
+			ifFalse: [ self applyAttribute: attribute ]].
+	^ true.! !
+
+!TextEditor methodsFor: 'undo & redo' stamp: 'pb 7/25/2017 21:30:11'!
+offerUndoHistory
+	| index labels current |
+	current _ model undoRedoCommandsPosition.
+	labels _ model undoRedoCommands withIndexCollect: [ :each :i |
+		(i = current) asMenuItemMarkerString , each printString ].
+	labels isEmpty ifFalse: [
+		index _ (PopUpMenu
+			labelArray: labels
+			lines: #()) startUpMenu.
+		index = current ifTrue: [ ^ self ].
+		index = 0 ifTrue: [ ^ self ].
+		index < current
+			ifTrue: [ current - index timesRepeat: [ self undo ]]
+			ifFalse: [ index - current timesRepeat: [ self redo ]]].! !
+
+
+!Preferences class methodsFor: 'misc' stamp: 'pb 7/25/2017 21:25:46'!
+staggerPolicyString
+	"Answer the string to be shown in a menu to represent the 
+	stagger-policy status"
+	^ (self valueOfFlag: #reverseWindowStagger) asMenuItemMarkerString , 'stagger windows'.! !
+
+
+!AbstractFont class methodsFor: 'instance accessing' stamp: 'pb 7/25/2017 21:26:40'!
+fromUser: priorFont
+	"
+	AbstractFont fromUser
+	"
+	"Present a menu of available fonts, and if one is chosen, return it.
+	Otherwise return nil.
+	Show only baseFonts i.e. FamilyName, pointSize (but do not include emphasis, such as italic or bold)"
+	| fontList fontMenu active ptMenu label spec |
+	fontList _ AbstractFont familyNames.
+	fontMenu _ MenuMorph new defaultTarget: self.
+	fontList do: [ :fontName |
+		active _ priorFont familyName sameAs: fontName.
+		ptMenu _ MenuMorph new defaultTarget: self.
+		(AbstractFont pointSizesFor: fontName) do: [ :pt |
+			label _ (active and: [ pt = priorFont pointSize ]) asMenuItemMarkerString.
+			label _ label , pt printString , ' pt'.
+			ptMenu
+				add: label
+				target: fontMenu
+				selector: #modalSelection:
+				argument: {fontName. pt} ].
+		label _ active asMenuItemMarkerString.
+		label _ label , fontName.
+		fontMenu
+			add: label
+			subMenu: ptMenu ].
+	spec _ fontMenu invokeModal.
+	spec ifNil: [ ^ nil ].
+	^ AbstractFont
+		familyName: spec first
+		pointSize: spec last.! !
+
+
+!Morph methodsFor: 'menus' stamp: 'pb 7/25/2017 21:26:57'!
+lockedString
+	"Answer the string to be shown in a menu to represent the 
+	'locked' status"
+	^ self isLocked asMenuItemMarkerString , 'be locked'.! !
+
+!Morph methodsFor: 'menus' stamp: 'pb 7/25/2017 21:25:34'!
+stickinessString
+	"Answer the string to be shown in a menu to represent the  
+	stickiness status"
+	^ self isSticky asMenuItemMarkerString , 'resist being picked up'.! !
+
+
+!InnerTextMorph methodsFor: 'menu' stamp: 'pb 7/25/2017 21:25:11'!
+wrapString
+	"Answer the string to put in a menu that will invite the user to 
+	switch word wrap mode"
+	^ wrapFlag asMenuItemMarkerString , 'text wrap to bounds'.! !
+
+
+!TheWorldMenu methodsFor: 'commands' stamp: 'pb 7/25/2017 21:30:06'!
+setDisplayDepth
+	"Let the user choose a new depth for the display. "
+	| result oldDepth allDepths allLabels menu hasBoth |
+	oldDepth _ Display nativeDepth.
+	allDepths _ #(1 -1 2 -2 4 -4 8 -8 16 -16 32 -32 ) select: [ :d |
+		Display supportsDisplayDepth: d ].
+	hasBoth _ (allDepths anySatisfy: [ :d |
+		d > 0 ]) and: [
+		allDepths anySatisfy: [ :d |
+			d < 0 ]].
+	allLabels _ allDepths collect: [ :d |
+		String streamContents: [ :s |
+			s nextPutAll: (d = oldDepth) asMenuItemMarkerString.
+			s print: d abs.
+			hasBoth ifTrue: [
+				s nextPutAll:
+					(d > 0
+						ifTrue: [ '  (big endian)' ]
+						ifFalse: [ '  (little endian)' ]) ]]].
+	menu _ SelectionMenu
+		labels: allLabels
+		selections: allDepths.
+	result _ menu startUpWithCaption: 'Choose a display depth'.
+	result ifNotNil: [ Display newDepth: result ].
+	oldDepth _ oldDepth abs.! !
+
+
+!Boolean reorganize!
+('logical operations' & eqv: not |)
+('controlling' and: and:and: and:and:and: and:and:and:and: ifFalse: ifFalse:ifTrue: ifTrue: ifTrue:ifFalse: or: or:or: or:or:or: or:or:or:or:)
+('copying' shallowCopy)
+('printing' isLiteral storeOn:)
+('converting' asMenuItemMarkerString)
+!
+

--- a/CoreUpdates/3136-Debugger-ensure-focus-released-fix-PhilBellalouna-2017Jul27-03h27m-pb.1.cs.st
+++ b/CoreUpdates/3136-Debugger-ensure-focus-released-fix-PhilBellalouna-2017Jul27-03h27m-pb.1.cs.st
@@ -1,0 +1,41 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3131] on 27 July 2017 at 3:27:46 am'!
+
+!Debugger class methodsFor: 'opening' stamp: 'pb 7/27/2017 03:27:10'!
+openOn: process context: context label: title fullView: bool
+	"Open a notifier in response to an error, halt, or notify. A notifier view just shows a short view of the sender stack and provides a menu that lets the user open a full debugger."
+	| w |
+	Preferences logDebuggerStackToFile ifTrue: [
+		Smalltalk
+			logError: title
+			inContext: context
+			to: 'CuisDebug.log' ].
+	w := ProjectX newProcessIfUIX: process.
+	"schedule debugger in deferred UI message to address redraw
+	problems after opening a debugger e.g. from the testrunner."
+	WorldState addDeferredUIMessage: [
+		[ | debugger |
+		"In case an error in Morphic code got us here, ensure mouse focus has been released"
+		true runningWorld ifNotNil: [ :rWorld |
+			rWorld activeHand ifNotNil: [ :aHand |
+				aHand releaseMouseFocus ]].
+		debugger := self new
+			process: process
+			context: context.
+		debugger interruptedProcessUI: w.
+		bool
+			ifTrue: [ debugger openFullMorphicLabel: title ]
+			ifFalse: [
+				PreDebugWindow
+					open: debugger
+					label: title
+					message: nil ]]
+			on: UnhandledError
+			do: [ :exOuter | | errorDescription |
+				errorDescription := 'Error while trying to open Debugger' , String newLineString , 'Orginal error: ' , title asString , '.' , String newLineString , '	Debugger error: ' ,
+					([ exOuter description ]
+						on: UnhandledError
+						do: [ :exInner |
+							exInner return: 'a ' , exInner class printString ]) , ':'.
+				self primitiveError: errorDescription ]].
+	process suspend.! !
+

--- a/CoreUpdates/3137-FileList-dynamic-registration-PhilBellalouna-2017Jul27-05h59m-pb.1.cs.st
+++ b/CoreUpdates/3137-FileList-dynamic-registration-PhilBellalouna-2017Jul27-05h59m-pb.1.cs.st
@@ -1,0 +1,57 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3130] on 27 July 2017 at 6:26:56 am'!
+!classDefinition: #FileList category: #'Tools-FileList'!
+TextProvider subclass: #FileList
+	instanceVariableNames: 'acceptedContentsCache fileName directory list listIndex pattern sortMode brevityState sortAscending showDirsInFileList currentDirectorySelected '
+	classVariableNames: 'FileReaderRegistry '
+	poolDictionaries: ''
+	category: 'Tools-FileList'!
+
+!FileList class methodsFor: 'file reader registration' stamp: 'pb 7/27/2017 06:05:51'!
+itemsForFile: filename
+	"Answer a list of services appropriate for a file of the given name"
+	| services suffix classList |
+	suffix _ (FileIOAccessor default extensionFor: filename) asLowercase.
+	services _ OrderedCollection new.
+	"Build the list dynamically for all implementers of the appropriate class method... registration no longer required"
+	classList _ (Smalltalk allClassesImplementing: #fileReaderServicesForFile:suffix:)
+		collect: [ :item |
+			item class == Metaclass ifTrue: [ item soleInstance ]]
+		thenSelect: [ :item |
+			item notNil ].
+	classList do: [ :reader |
+		reader ifNotNil: [
+			services addAll:
+				(reader
+					fileReaderServicesForFile: filename
+					suffix: suffix) ]].
+	^ services.! !
+
+!FileList class methodsFor: 'file reader registration' stamp: 'pb 7/27/2017 06:02:20'!
+registerFileReader: aProviderClass
+	"For compatibility... no longer necessary"! !
+
+!FileList class methodsFor: 'file reader registration' stamp: 'pb 7/27/2017 06:02:32'!
+unregisterFileReader: aProviderClass
+	"For compatibility... no longer necessary"! !
+
+!methodRemoval: Morph class #unload!
+Morph class removeSelector: #unload!
+!methodRemoval: Form class #unload!
+Form class removeSelector: #unload!
+!methodRemoval: FileList class #initialize!
+FileList class removeSelector: #initialize!
+!methodRemoval: ChangeSorter class #unload!
+ChangeSorter class removeSelector: #unload!
+!methodRemoval: ChangeList class #unload!
+ChangeList class removeSelector: #unload!
+!methodRemoval: CodeFileBrowser class #unload!
+CodeFileBrowser class removeSelector: #unload!
+!methodRemoval: MessageNames class #unload!
+MessageNames class removeSelector: #unload!
+!classDefinition: #FileList category: #'Tools-FileList'!
+TextProvider subclass: #FileList
+	instanceVariableNames: 'acceptedContentsCache fileName directory list listIndex pattern sortMode brevityState sortAscending showDirsInFileList currentDirectorySelected'
+	classVariableNames: ''
+	poolDictionaries: ''
+	category: 'Tools-FileList'!
+FileList initialize!

--- a/CoreUpdates/3138-HierarchicalListMorph-shift-key-fully-expands-PhilBellalouna-2017Jul27-14h17m-pb.1.cs.st
+++ b/CoreUpdates/3138-HierarchicalListMorph-shift-key-fully-expands-PhilBellalouna-2017Jul27-14h17m-pb.1.cs.st
@@ -1,0 +1,12 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3130] on 27 July 2017 at 2:24:40 pm'!
+
+!HierarchicalListMorph methodsFor: 'commands' stamp: 'pb 7/27/2017 14:24:23'!
+toggleExpandedState: aMorph event: event
+
+	"self setSelectedMorph: aMorph."
+	((self autoExpand or: [event shiftPressed]) and: [aMorph isExpanded not])
+		ifTrue: [aMorph beFullyExpanded]
+		ifFalse: [aMorph toggleExpandedState].
+	scroller adjustExtent.
+	self setScrollDeltas! !
+


### PR DESCRIPTION
…ollows on this)

Re: PluggableButtonMorph>>morphExtent - I read your comment and understand the issue re: icon extent and things like TaskBarMorph (which is easily fixed) but disagree with the assertion.  I can think of several use cases of more dynamic buttons where the existing approach will cause problems (a couple of examples: a taskbar with an OS X style 'genie effect', buttons displaying pictures in a scalable grid, etc.)  In the absence of better information, it seems reasonable for the initial button extent to use the icon extent and that it is up to the sender to provide the icon size they want rather than have the button prescale the source image 'on the way in' based on the current button size (which leads to ugly scaling artifacts in the case of TaskBarMorph).  Rather, it seems to make more sense to have the application prescale to the maximum size it is likely to want to use, if necessary.  Then have the button scale the destination (i.e. 'magnifiedIcon') image for drawing efficiency so that the desired button size can change over time (see TaskBarMorph and its existing x2/x4 scaling option)

In cases like this where the source image and/or the initial button size and/or the final button size may not match, why not just override the calculated extent as needed? (just as nearly everything appears to be doing under the current layout system anyway... other than window controls (and even they don't really), does anything actually use the hard-coded default values?)  In this latest changeset I've significantly pre-scaled down the TaskBarMorph icons (128@128 seemed reasonable since some people might want the x2 or x4 magnification (retina displays etc.) but even 64@64 would be a significant improvement over the current extent dimensions.  Another possiblity would be to rebuild the icons when the scale is changed and then we could scale exactly to the button extent.)  The goal of the #morphExtent changes was to try to produce an extent that will at least sometimes be what you want vs. the current state where it's almost never what you want (at least not in my experience with the current hard-coded default.)  This is why it's only calculated once and only when the extent is nil: if an extent already exists, assume whoever set it has better information.