### PR TITLE
Update VM download link and version

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -23,7 +23,7 @@ Note: For 32 bits Linux on Intel/AMD, use ```*_linux32x86_*``` vm and the ```*-3
 ```
 cd MyProject
 rm -r cogspur
-wget -O cogspur.tgz https://bintray.com/opensmalltalk/vm/download_file?file_path=squeak.cog.spur_linux64x64_201805221836.tar.gz
+wget -O cogspur.tgz https://dl.bintray.com/opensmalltalk/vm/squeak.cog.spur_linux64x64_201808190913.tar.gz
 tar -zxvf cogspur.tgz
 mv ./sqcogspur64linuxht ./cogspur
 ```


### PR DESCRIPTION
The previous link gave a 404 and that version is not available either.