### PR TITLE
fix for allowing to compare Array2D

### DIFF
--- a/CoreUpdates/3774-FailedWhenYouCompareTwoArray2DByEqual-GonzaloSanchezCano.st
+++ b/CoreUpdates/3774-FailedWhenYouCompareTwoArray2DByEqual-GonzaloSanchezCano.st
@@ -1,0 +1,6 @@
+'From Cuis 5.0 of 7 November 2016 [latest update: #3720] on 26 May 2019 at 11:05:05 pm'!
+
+!Array2D methodsFor: 'accessing' stamp: 'GSC 5/26/2019 23:04:56'!
+elements
+
+	^elements! !


### PR DESCRIPTION
Before: 
When you tried to compare Array2D was failing because a missing message. For example in this case: (Array2D newSize: 3@3) = (Array2D newSize: 3@3)

Now: 
It's fixed