### PR TITLE
Run base tests on Travis CI

### DIFF
--- a/.ContinuousIntegrationScripts/TestResultConsolePrinter.st
+++ b/.ContinuousIntegrationScripts/TestResultConsolePrinter.st
@@ -1,0 +1,139 @@
+'From Cuis 5.0 [latest update: #3877] on 16 September 2019 at 7:37:07 pm'!
+!classDefinition: #TestResultConsolePrinter category: #'System-Support'!
+Object subclass: #TestResultConsolePrinter
+	instanceVariableNames: 'outputStream'
+	classVariableNames: ''
+	poolDictionaries: ''
+	category: 'System-Support'!
+!classDefinition: 'TestResultConsolePrinter class' category: #'System-Support'!
+TestResultConsolePrinter class
+	instanceVariableNames: 'stdOutCommandLine'!
+
+!TestResultConsolePrinter methodsFor: 'initialization' stamp: 'FJG 9/15/2019 03:44:31'!
+initializeWith: aWriteStream
+
+	outputStream _ aWriteStream
+	! !
+
+!TestResultConsolePrinter methodsFor: 'printing' stamp: 'FJG 9/15/2019 03:48:28'!
+print: aString
+
+	outputStream nextPutAll: aString; newLine! !
+
+!TestResultConsolePrinter methodsFor: 'printing' stamp: 'GC 9/16/2019 19:07:31'!
+printError: aTestCase because: anExceptionSignal
+	| exception |
+	
+	exception _ anExceptionSignal exception.
+	
+	self printInRed: ('&#16r274C; {1} has errored because: {2}' format: {aTestCase asString . exception asString })! !
+
+!TestResultConsolePrinter methodsFor: 'printing' stamp: 'GC 9/16/2019 19:07:16'!
+printFailed: aTestCase because: aCause
+
+	self printInRed: ('&#16r274C; {1} has failed because: {2}' format: {aTestCase asString . aCause asString })! !
+
+!TestResultConsolePrinter methodsFor: 'printing' stamp: 'GC 9/16/2019 19:14:03'!
+printInGreen: aString
+
+	outputStream nextPutAll: Character escape asString, '[32m'.
+	self print: aString.	
+	outputStream nextPutAll: Character escape asString, '[0m'.
+	outputStream flush! !
+
+!TestResultConsolePrinter methodsFor: 'printing' stamp: 'GC 9/16/2019 19:13:34'!
+printInRed: aString
+
+	outputStream nextPutAll: Character escape asString, '[31m'.
+	self print: aString.	
+	outputStream nextPutAll: Character escape asString, '[0m'.
+	outputStream flush! !
+
+!TestResultConsolePrinter methodsFor: 'printing' stamp: 'GC 9/16/2019 19:12:25'!
+printPassed: aTestCase
+
+	self printInGreen: '&#16r2713; ', aTestCase asString! !
+
+!TestResultConsolePrinter methodsFor: 'printing' stamp: 'GC 9/16/2019 19:07:59'!
+printReport: aTestResult
+	| failuresCount |
+	
+	self print: aTestResult asString.
+	
+	failuresCount _ (aTestResult errors, aTestResult failures) size.
+	failuresCount isZero ifTrue: [
+		self
+			printInGreen: '--------';
+		      printInGreen: 'SUCCESS';
+			printInGreen: '--------'.
+	] ifFalse: [
+		self printInRed: '--------';
+			 printInRed: failuresCount asString, ' FAILURE(S)';
+			 printInRed: '--------'.
+		aTestResult errors do: [:aTestCase |
+			self printError: aTestCase because: aTestCase raisedError
+		].
+		aTestResult failures do: [:aTestCase |
+			self printFailed: aTestCase because: aTestCase failureString
+		]
+	]! !
+
+
+!TestResultConsolePrinter class methodsFor: 'instance creation' stamp: 'FJG 9/15/2019 01:41:17'!
+stdOutCommandLine
+
+	^ stdOutCommandLine ifNil: [
+		stdOutCommandLine _ self new initializeWith: StdIOWriteStream stdout; yourself
+	]! !
+
+!TestResultConsolePrinter class methodsFor: 'stdout printing' stamp: 'FJG 9/15/2019 03:24:22'!
+printError: aTestCase because: anExceptionSignal
+
+	self stdOutCommandLine printError: aTestCase because: anExceptionSignal! !
+
+!TestResultConsolePrinter class methodsFor: 'stdout printing' stamp: 'FJG 9/15/2019 03:24:42'!
+printFailed: aTestCase because: anException
+
+	self stdOutCommandLine printFailed: aTestCase because: anException! !
+
+!TestResultConsolePrinter class methodsFor: 'stdout printing' stamp: 'FJG 9/15/2019 03:23:05'!
+printPassed: aTestCase
+
+	self stdOutCommandLine printPassed: aTestCase! !
+
+!TestResultConsolePrinter class methodsFor: 'stdout printing' stamp: 'FJG 9/15/2019 03:22:14'!
+printReport: aTestResult
+
+	self stdOutCommandLine printReport: aTestResult! !
+
+
+!TestResult methodsFor: 'running' stamp: 'FJG 9/15/2019 03:22:19'!
+printReport
+
+	TestResultConsolePrinter printReport: self! !
+
+
+!TestResult methodsFor: 'running' stamp: 'FJG 9/15/2019 03:26:17'!
+reportError: aTestCase because: anExceptionSignal
+	
+	TestResultConsolePrinter printError: aTestCase because: anExceptionSignal! !
+
+!TestResult methodsFor: 'running' stamp: 'FJG 9/15/2019 03:25:11'!
+reportFailed: aTestCase because: anException
+	
+	TestResultConsolePrinter printFailed: aTestCase because: anException! !
+
+!TestResult methodsFor: 'running' stamp: 'FJG 9/15/2019 03:23:35'!
+reportPassed: aTestCase
+	
+	TestResultConsolePrinter printPassed: aTestCase! !
+
+
+!TestResult reorganize!
+('accessing' correctCount defects errorCount errors failureCount failures passed passedCount removeFromDefectsAndAddToPassed: runCount tests)
+('testing' hasErrors hasFailures hasPassed isError: isFailure: isPassed:)
+('printing' printOn:)
+('running' printReport reportError:because: reportFailed:because: reportPassed: runCase:)
+('logging' reportAboutToRun:)
+!
+

--- a/.ContinuousIntegrationScripts/installUpdates.sh
+++ b/.ContinuousIntegrationScripts/installUpdates.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IMAGE_FILE="$(ls | grep 'Cuis5.0-[0-9]\+.image')"
+
+./sqcogspur64linuxht/bin/squeak -vm-display-null "$IMAGE_FILE" -d "\
+    ChangeSet installNewUpdates.\
+    Smalltalk snapshot: true andQuit: true clearAllClassState: false.\
+    "

--- a/.ContinuousIntegrationScripts/linux.sh
+++ b/.ContinuousIntegrationScripts/linux.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Setting up VM for linux"
+
+wget https://github.com/OpenSmalltalk/opensmalltalk-vm/releases/download/201901172323/squeak.cog.spur_linux64x64_201901172323.tar.gz
+tar -xvzf squeak.cog.spur_linux64x64_201901172323.tar.gz
+sqcogspur64linuxht/bin/squeak --version

--- a/.ContinuousIntegrationScripts/macos.sh
+++ b/.ContinuousIntegrationScripts/macos.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo "Setting up VM for macos"
+
+wget https://github.com/OpenSmalltalk/opensmalltalk-vm/releases/download/201901172323/squeak.cog.spur_macos64x64_201901172323.dmg
+sudo hdiutil attach squeak.cog.spur_macos64x64_201901172323.dmg
+ls -a /Volumes
+cd /Volumes/squeak.cog.spur_macos64x64_201901172323
+sudo cp -rf Squeak.app /Applications

--- a/.ContinuousIntegrationScripts/runTests.sh
+++ b/.ContinuousIntegrationScripts/runTests.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IMAGE_FILE="$(ls | grep 'Cuis5.0-[0-9]\+.image')"
+TEST_TEMPORAL_DIR=$(mktemp -d)
+TEST_TEMPORAL_IMG="$TEST_TEMPORAL_DIR/cuis.image"
+
+cp "$IMAGE_FILE" "$TEST_TEMPORAL_IMG"
+
+sqcogspur64linuxht/bin/squeak -vm-display-null "$TEST_TEMPORAL_IMG" -s .ContinuousIntegrationScripts/runTests.st
+
+rm -r "$TEST_TEMPORAL_DIR"

--- a/.ContinuousIntegrationScripts/runTests.st
+++ b/.ContinuousIntegrationScripts/runTests.st
@@ -1,0 +1,20 @@
+|suite result exitCode|
+
+Utilities classPool at: #AuthorName put: 'TravisCI'.
+Utilities classPool at: #AuthorInitials put: 'TCI'.
+
+CodePackageFile installPackage: './Packages/BaseImageTests.pck.st' asFileEntry.
+
+ChangeSet fileIn: './.ContinuousIntegrationScripts/TestResultConsolePrinter.st' asFileEntry.
+
+testSuite := TestSuite new.
+testCases := TestCase allSubclasses reject: [:testCase | testCase isAbstract].
+testCases do: [:testCase | testCase addToSuiteFromSelectors: testSuite].
+
+result := testSuite run.
+
+result printReport.
+
+exitCode := (result hasFailures or: [ result hasErrors ]) ifTrue: [ 1 ] ifFalse: [ 0 ].
+
+Smalltalk quitPrimitive: exitCode

--- a/.ContinuousIntegrationScripts/runTestsLinux.sh
+++ b/.ContinuousIntegrationScripts/runTestsLinux.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+.ContinuousIntegrationScripts/installUpdates.sh
+.ContinuousIntegrationScripts/runTests.sh

--- a/.ContinuousIntegrationScripts/runTestsmacos.sh
+++ b/.ContinuousIntegrationScripts/runTestsmacos.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+IMAGE_FILE="$(ls | grep 'Cuis5.0-[0-9]\+.image')"
+TEST_TEMPORAL_DIR=$(mktemp -d)
+TEST_TEMPORAL_IMG="$TEST_TEMPORAL_DIR/cuis.image"
+
+/Applications/Squeak.app/Contents/MacOS/Squeak -version
+/Applications/Squeak.app/Contents/MacOS/Squeak -headless "$TEST_TEMPORAL_IMG" -s .ContinuousIntegrationScripts/runTests.st

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: minimal
+
+git:
+  depth: 1
+
+os:
+  - linux
+
+before_install:
+  - wget https://github.com/OpenSmalltalk/opensmalltalk-vm/releases/download/201901172323/squeak.cog.spur_linux64x64_201901172323.tar.gz
+  - tar -xvzf squeak.cog.spur_linux64x64_201901172323.tar.gz
+  - sqcogspur64linuxht/bin/squeak --version
+
+script:
+  - .ContinuousIntegrationScripts/installUpdates.sh
+  - .ContinuousIntegrationScripts/runTests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ git:
 
 os:
   - linux
+  - osx
 
 before_install:
-  - wget https://github.com/OpenSmalltalk/opensmalltalk-vm/releases/download/201901172323/squeak.cog.spur_linux64x64_201901172323.tar.gz
-  - tar -xvzf squeak.cog.spur_linux64x64_201901172323.tar.gz
-  - sqcogspur64linuxht/bin/squeak --version
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then .ContinuousIntegrationScripts/macos.sh ; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then .ContinuousIntegrationScripts/linux.sh ; fi
 
 script:
-  - .ContinuousIntegrationScripts/installUpdates.sh
-  - .ContinuousIntegrationScripts/runTests.sh
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then .ContinuousIntegrationScripts/runTestsLinux.sh ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then .ContinuousIntegrationScripts/runTestsmacos.sh ; fi


### PR DESCRIPTION
## Continuous Integration for Cuis
This changes will allow us to automatically run the system tests on a Continuous Integration server (Travis CI) every time a push is done.

:scroll: The report that's generated after running the tests looks like this:
![test report](https://user-images.githubusercontent.com/12160875/65189700-1c5f0300-da48-11e9-8086-0cc2e223baa1.png)

You can find an example of a build here: https://travis-ci.org/gstn-caruso/Cuis-Smalltalk-Dev/builds/585824993?utm_source=github_status&utm_medium=notification

### Details
The steps that we do when running CI are:
1. Download the Cog VM (currently we're always using the `201901172323` release).
2. Clone the Cuis repo.
3. Install the updates on the Cuis image.
4. File in and run the base tests.
5. If any of these steps fail, the build fails.

### Next steps
After merging this, we have to change the repo configuration to start using Travis CI, for this to start working :gear:.

In the future, we could do more things apart from just running system tests, like:
- :package: Run tests from well-known packages (e.g. WebClient, OpenCL, AMQP).
- :computer: Publish updates to the Cuis website.
- :inbox_tray: Generate releases (.zip files for every platform, that include the VM and all the files needed to start with one click :raised_hands:).

Authors: @gstn-caruso @javiergelatti
