### PR TITLE
doc: fix statusAllRepos.sh script name on getting started readme

### DIFF
--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -25,7 +25,7 @@ After that, you may periodically update all your repos from GitHub:
 ```
 Additionally, after doing your stuff, you can check what you need to commit to GitHub:
 ```
-./Cuis-Smalltalk-Dev/gitStatusAllRepos.sh
+./Cuis-Smalltalk-Dev/statusAllRepos.sh
 ```
 
 ## For 64 bits Linux running on AMD/Intel x64 hardware ##


### PR DESCRIPTION
Minor fix on script name from the getting started readme.