### PR TITLE
Run tests with github actions

### DIFF
--- a/.ContinuousIntegrationScripts/installUpdates.sh
+++ b/.ContinuousIntegrationScripts/installUpdates.sh
@@ -8,20 +8,20 @@ INSTALL_UPDATES_SCRIPT="\
   Utilities classPool at: #AuthorName put: 'TravisCI'.
   Utilities classPool at: #AuthorInitials put: 'TCI'.
   ChangeSet installNewUpdates.\
-  Smalltalk snapshot: true andQuit: true clearAllClassState: false.\
+  Smalltalk saveAndQuit.\
 "
 
 installUpdatesLinux() {
-  ./sqcogspur64linuxht/bin/squeak -vm-display-null "$IMAGE_FILE" -d "$INSTALL_UPDATES_SCRIPT"
+  /home/runner/work/Cuis-Smalltalk-Dev/Cuis-Smalltalk-Dev/sqcogspur64linux/bin/squeak -vm-display-null "$IMAGE_FILE" -d "$INSTALL_UPDATES_SCRIPT"
 }
 
 installUpdatesMacOS() {
   /Applications/Squeak.app/Contents/MacOS/Squeak -headless "$IMAGE_FILE" -d "$INSTALL_UPDATES_SCRIPT"
 }
 
-case $TRAVIS_OS_NAME in
-  "linux")
+case $RUNNER_OS in
+  "Linux")
     installUpdatesLinux ;;
-  "osx")
+  "macOS")
     installUpdatesMacOS ;;
 esac

--- a/.ContinuousIntegrationScripts/installVm.sh
+++ b/.ContinuousIntegrationScripts/installVm.sh
@@ -4,14 +4,16 @@ set -euo pipefail
 VM_VERSION="201911012148"
 BASE_VM_DOWNLOAD_PATH="https://github.com/OpenSmalltalk/opensmalltalk-vm/releases/download/$VM_VERSION"
 
-echo "Installing VM $VM_VERSION for $TRAVIS_OS_NAME"
+echo "Installing VM $VM_VERSION for $RUNNER_OS"
 
 installVmLinux() {
-  VM_FILENAME="squeak.cog.spur_linux64x64_$VM_VERSION"
+  sudo apt-get update
+  sudo apt-get install pulseaudio
+  VM_FILENAME="squeak.cog.spur_linux64x64_itimer_$VM_VERSION"
 
   wget "$BASE_VM_DOWNLOAD_PATH/$VM_FILENAME.tar.gz"
   tar -xvzf "$VM_FILENAME.tar.gz"
-  sqcogspur64linuxht/bin/squeak --version
+  sqcogspur64linux/bin/squeak --version
 }
 
 installVmMacOS() {
@@ -23,9 +25,9 @@ installVmMacOS() {
   sudo cp -rf Squeak.app /Applications
 }
 
-case $TRAVIS_OS_NAME in
-  "linux")
+case $RUNNER_OS in
+  "Linux")
     installVmLinux ;;
-  "osx")
+  "macOS")
     installVmMacOS ;;
 esac

--- a/.ContinuousIntegrationScripts/runTests.sh
+++ b/.ContinuousIntegrationScripts/runTests.sh
@@ -6,16 +6,16 @@ IMAGE_FILE="$(ls | grep 'Cuis5.0-[0-9]\+.image')"
 RUN_TESTS_SCRIPT_FILEPATH=".ContinuousIntegrationScripts/runTests.st"
 
 runTestsOnLinux() {
-  sqcogspur64linuxht/bin/squeak -vm-display-null "$IMAGE_FILE" -s "$RUN_TESTS_SCRIPT_FILEPATH"
+  /home/runner/work/Cuis-Smalltalk-Dev/Cuis-Smalltalk-Dev/sqcogspur64linux/bin/squeak -vm-display-null "$IMAGE_FILE" -s "$RUN_TESTS_SCRIPT_FILEPATH"
 }
 
 runTestsOnMacOS() {
   /Applications/Squeak.app/Contents/MacOS/Squeak -headless "$IMAGE_FILE" -s "$RUN_TESTS_SCRIPT_FILEPATH"
 }
 
-case $TRAVIS_OS_NAME in
-  "linux")
+case $RUNNER_OS in
+  "Linux")
     runTestsOnLinux ;;
-  "osx")
+  "macOS")
     runTestsOnMacOS ;;
 esac

--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -1,0 +1,19 @@
+name: Run tests
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+jobs:
+  Build:
+    runs-on: '${{ matrix.os }}'
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - run: .ContinuousIntegrationScripts/installVm.sh
+      - run: .ContinuousIntegrationScripts/installUpdates.sh
+      - run: .ContinuousIntegrationScripts/runTests.sh


### PR DESCRIPTION
Since it was tuff to fix the travis ci integration and the effort to migrate to github actions isn't much this changes intend to run the tests with github actions using ubuntu and macos images.