### PR TITLE
Thousand separator for Printf -- aka : pretty print financial values

### DIFF
--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 10:26:57 pm'!
+'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 10:33:57 pm'!
 'Description '!
-!provides: 'Printf' 1 28!
+!provides: 'Printf' 1 29!
 SystemOrganization addCategory: #Printf!
 
 
@@ -299,7 +299,7 @@ stopIndexOfCopyReplaceWithStringSize: anInteger
 flush
 	^ flush! !
 
-!PrintfFormatDescriptor methodsFor: 'private' stamp: 'NM 1/15/2022 19:51:34'!
+!PrintfFormatDescriptor methodsFor: 'private' stamp: 'NM 1/15/2022 22:33:18'!
 operator: char
 	| myself |
 	myself := (Smalltalk at: (Operators at: char)) newFrom: self.
@@ -307,7 +307,7 @@ operator: char
 	". case of the floating point with thousand separator, not good here, just a start " 
 	((self class = PrintfNumberFormatDescriptor) and:
 	 (myself class = PrintfFloatFormatDescriptor )) ifTrue: [
-		Transcript show: 'DBG --- Transforming a float with thousand sep ' . 
+		"Transcript show: 'DBG --- Transforming a float with thousand sep ' . "
 		" myself thousandSeparator: (self thousandSeparator) "
 		].
 	^ myself
@@ -586,7 +586,7 @@ addThousandSeparator: numberString
 				'.' , decimalPart . 
 	! !
 
-!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 22:09:09'!
+!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 22:31:19'!
 applyOperator: object 
 	"Number is the only valid class"
 	| string out |
@@ -607,13 +607,15 @@ applyOperator: object
 			ifTrue: [String new: width withAll: $*]
 			ifFalse: [string].
 	" . add thousand separators, if needed " 
-	Transcript show: 'DBG --- applyOperator for FLoat numbers '.
+	"Transcript show: 'DBG --- applyOperator for FLoat numbers '. "
 	thousandSeparate 
 		ifTrue: [
-			Transcript show: 'DBG --- thousand sep is ON'.
+			"Transcript show: 'DBG --- thousand sep is ON'. "
 			out _ self addThousandSeparator: out. 
 			] 
-		ifFalse: [Transcript show: 'DBG --- thousand sep is OFF'] . 
+		ifFalse: [
+			"Transcript show: 'DBG --- thousand sep is OFF' "
+			] . 
 	^ out 		
 			
 		! !

--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 5:27:12 pm'!
+'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 9:50:28 pm'!
 'Description '!
-!provides: 'Printf' 1 22!
+!provides: 'Printf' 1 26!
 SystemOrganization addCategory: #Printf!
 
 
@@ -219,6 +219,14 @@ printWidthOn: aStream
 	precision ifNotNil: [aStream nextPut: $.. precision printOn: aStream]
 	! !
 
+!PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 19:54:31'!
+doThousandSeparate
+	|out| 
+	out _ (PrintfNumberFormatDescriptor newFrom: self) .
+	out thousandSeparate: true.
+	^ out 
+	! !
+
 !PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 8/16/2021 14:07:52'!
 leftFlush
 	flush := #leftFlush
@@ -239,14 +247,14 @@ space
 	^ (PrintfNumberFormatDescriptor newFrom: self) space
 	! !
 
-!PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 15:12:59'!
-thousandSeparate
-	^ (PrintfNumberFormatDescriptor newFrom: self) thousandSeparate
-	! !
-
-!PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 8/16/2021 14:13:20'!
+!PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 18:43:55'!
 zero
-	^ (PrintfNumberFormatDescriptor newFrom: self) zero
+	|out| 
+	(self class = PrintfNumberFormatDescriptor) 
+	ifTrue: [ out _ self zero ] 
+	ifFalse: [ out _ (PrintfNumberFormatDescriptor newFrom: self) zero ].
+	^ out 
+	" ^ (PrintfNumberFormatDescriptor newFrom: self) zero "
 	! !
 
 !PrintfFormatDescriptor methodsFor: 'rendering' stamp: 'NM 8/16/2021 14:07:00'!
@@ -291,11 +299,17 @@ stopIndexOfCopyReplaceWithStringSize: anInteger
 flush
 	^ flush! !
 
-!PrintfFormatDescriptor methodsFor: 'private' stamp: 'NM 8/16/2021 14:08:31'!
+!PrintfFormatDescriptor methodsFor: 'private' stamp: 'NM 1/15/2022 19:51:34'!
 operator: char
 	| myself |
 	myself := (Smalltalk at: (Operators at: char)) newFrom: self.
 	myself setOperator: char.
+	". case of the floating point with thousand separator, not good here, just a start " 
+	((self class = PrintfNumberFormatDescriptor) and:
+	 (myself class = PrintfFloatFormatDescriptor )) ifTrue: [
+		Transcript show: 'DBG --- Transforming a float with thousand sep ' . 
+		" myself thousandSeparator: (self thousandSeparator) "
+		].
 	^ myself
 	! !
 
@@ -375,7 +389,7 @@ scanFrom: stream
 	
 	! !
 
-!PrintfFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 14:49:18'!
+!PrintfFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 19:53:06'!
 initialize
 	"PrintfFormatDescriptor initialize"
 	Operators := Dictionary new.
@@ -393,7 +407,7 @@ initialize
 	Flags at: $  put: #space.
 	Flags at: $# put: #radix.
 	Flags at: $0 put: #zero.
-	Flags at: $_ put: #thousandSeparate
+	Flags at: $_ put: #doThousandSeparate
 	
 	
 	
@@ -487,17 +501,31 @@ space
 	space := true
 	! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 15:15:58'!
+!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 19:55:07'!
 thousandSeparate
-	Transcript log: '--> Called thousandSeparate '. 
-	thousandSeparate := true.! !
+	^ thousandSeparate  ! !
+
+!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 19:55:15'!
+thousandSeparate: aBoolean
+	thousandSeparate _ aBoolean .
+! !
+
+!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 19:21:01'!
+thousandSeparator
+	^ thousandSeparator
+	! !
+
+!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 19:20:47'!
+thousandSeparator: aCharacter
+	thousandSeparator _ aCharacter .
+	! !
 
 !PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 8/16/2021 14:34:26'!
 zero
 	padding := $0
 	! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'initialize-release' stamp: 'NM 1/15/2022 14:47:54'!
+!PrintfNumberFormatDescriptor methodsFor: 'initialize-release' stamp: 'NM 1/15/2022 18:47:47'!
 initialize
 	super initialize.
 	padding := $ .
@@ -505,7 +533,9 @@ initialize
 	space := false.
 	thousandSeparate := false .
 	" . TODO temporary value, we should by default set $, if decimal separator is $. and viceversa. "
-	thousandSeparator := $_ .! !
+	thousandSeparator := $_ .
+	". to permit print in the debugger " 
+	operator _ $? . ! !
 
 !PrintfNumberFormatDescriptor class methodsFor: 'instance creation' stamp: 'NM 8/16/2021 14:35:16'!
 newFrom: desc
@@ -533,7 +563,7 @@ initialize
 	Cased := 'AaEeFfGgXx'
 	! !
 
-!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 8/16/2021 14:37:04'!
+!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 18:48:55'!
 applyOperator: object 
 	"Number is the only valid class"
 
@@ -551,10 +581,22 @@ applyOperator: object
 					ifFalse: [string asUppercase]].
 	(space and: [object asFloat >= 0]) ifTrue:
 		[string := ' ' , string].
+	Transcript show: 'DBG --- applyOperator for FLoat numbers '.
+	" self halt. " 
+	thousandSeparate ifTrue: [Transcript show: 'DBG --- thousand sep is ON'] 
+		ifFalse: [Transcript show: 'DBG --- thousand sep is OFF'] . 
 	^(width ~= 0 and: [string size > width])
 		ifTrue: [String new: width withAll: $*]
 		ifFalse: [string]
 		! !
+
+!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 21:49:03'!
+initializeThousandSeparatorFrom: descriptor 
+	(descriptor class = PrintfNumberFormatDescriptor) ifTrue: [
+		thousandSeparator _ (descriptor thousandSeparator ).
+		thousandSeparate  _ (descriptor thousandSeparate ).
+		].
+	^ self ! !
 
 !PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 8/16/2021 14:37:28'!
 zeroPaddedStringOfBase: base forFloat: aFloat 
@@ -578,6 +620,13 @@ precision
 !PrintfFloatFormatDescriptor methodsFor: 'private' stamp: 'NM 8/16/2021 14:36:49'!
 stringLength
 	^ width
+	! !
+
+!PrintfFloatFormatDescriptor class methodsFor: 'as yet unclassified' stamp: 'NM 1/15/2022 21:49:42'!
+newFrom: descriptor
+	descriptor class == self ifTrue: [^ descriptor].
+	^ ((super newFrom: descriptor) setPadding: descriptor padding) initializeThousandSeparatorFrom: descriptor 
+
 	! !
 
 !PrintfNumberHolderDescriptor methodsFor: 'rendering' stamp: 'NM 8/16/2021 14:38:35'!

--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 5:10:18 pm'!
+'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 5:25:08 pm'!
 'Description '!
-!provides: 'Printf' 1 20!
+!provides: 'Printf' 1 21!
 SystemOrganization addCategory: #Printf!
 
 
@@ -761,6 +761,39 @@ examples
 		printf: ((Array with: 'long' with: 'hello world' with: 'hello world' with: 42.0) copyWith: 42.1234567)).
 		! !
 
+!PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 1/15/2022 17:22:03'!
+test100_ThousandSeparator
+       ". small numbers are ignored "
+	self assert: (('%_d' printf: {123}) = '123' ) .
+	self assert: (('%_d' printf: {1234}) = '1_234' ) .
+	self assert: (('%_d' printf: {12345678}) = '12_345_678' ) .
+	". very large numbers must be ok "
+	self assert: (('%_d' printf: {123456789123456789}) = '123_456_789_123_456_789' ) .   
+	
+	! !
+
+!PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 1/15/2022 17:24:52'!
+test101_LargeFloat
+       ". this test was added to remember there is an ugly bug here "
+	self assert: ('%.2f' printf: {1.1}) = '1.10' .  
+	self assert: ('%.2f' printf: {12.1}) = '12.10' .  
+	self assert: ('%.2f' printf: {123.1}) = '123.10' . 
+       self assert: ('%.2f' printf: {1234.1}) = '1234.10' .	  
+	self assert: ('%.2f' printf: {12345.1}) = '12345.10' . 
+	self assert: ('%.2f' printf: {123456.1}) = '123456.10' .  
+	". from here on it is broken " 
+	self assert: ('%.2f' printf: {1234567.1}) = '1234567.10'.     ". gives wrongly 1.23"
+	self assert: ('%.2f' printf: {12345678.1}) = '12345678.10'.  ". gives wrongly 1.23"
+
+	! !
+
+!PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 1/15/2022 17:11:35'!
+testBigFloat
+	^ nil 
+      
+	
+	! !
+
 !PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 8/30/2021 18:39:08'!
 testFprintf
 	| stream expected |
@@ -770,6 +803,17 @@ testFprintf
 and a 0-padded limited precision one "%013.5e".'
 		printf: #('long' 'hello world' 'hello world' 42.0 42.1234567)).
 	self assert: expected equals: stream contents
+	! !
+
+!PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 1/15/2022 17:12:50'!
+testLargeFloat101
+       ". small numbers are ignored "
+	self assert: (('%_d' printf: {123}) = '123' ) .
+	self assert: (('%_d' printf: {1234}) = '1_234' ) .
+	self assert: (('%_d' printf: {12345678}) = '12_345_678' ) .
+	". very large numbers must be ok "
+	self assert: (('%_d' printf: {123456789123456789}) = '123_456_789_123_456_789' ) .   
+	
 	! !
 
 !PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 8/16/2021 14:47:49'!
@@ -838,17 +882,6 @@ testOneStringWithLength
 testReturnValue
 
 	self assert: 6+8 equals: ((PrintfFormatString new setFormat: 'hello %ld') printf: {12345678})
-	! !
-
-!PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 1/15/2022 17:02:07'!
-testThousandSeparator
-       ". small numbers are ignored "
-	self assert: (('%_d' printf: {123}) = '123' ) .
-	self assert: (('%_d' printf: {1234}) = '1_234' ) .
-	self assert: (('%_d' printf: {12345678}) = '12_345_678' ) .
-	". very large numbers must be ok "
-	self assert: (('%_d' printf: {123456789123456789}) = '123_456_789_123_456_789' ) .   
-	
 	! !
 
 !Object methodsFor: '*Printf' stamp: 'NM 8/16/2021 15:08:36'!

--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 4:29:48 pm'!
+'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 5:10:18 pm'!
 'Description '!
-!provides: 'Printf' 1 19!
+!provides: 'Printf' 1 20!
 SystemOrganization addCategory: #Printf!
 
 
@@ -436,13 +436,13 @@ stringLength
 		ifFalse: [precision]
 		! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 16:29:11'!
+!PrintfNumberFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 16:45:49'!
 addThousandSeparator: numberString
 	". receives in input an integer numberString e.g. '12345'
 	. returns in output a thousand separated string e.g. '12_345' 
 	. '_' is the value lf 'thousandSeparator' 
-	. if 'base' is not is not 10 returns just numberString, since a separation by 3 digits blocks
-	 would not mean what 'thousand' says; and print a warning in the Transcript'. 
+	. if 'base' is not is not 10 returns just 'numberString', since a separation by 3 digits blocks
+	 would not mean what 'thousand' says; in that case also print a warning in the Transcript'. 
 	"
 	(self base ~= 10) ifTrue:  [ 
 		Transcript log: 'Error. Printf. thousand separation is not defined for non base 10 numbers.' . 
@@ -838,6 +838,17 @@ testOneStringWithLength
 testReturnValue
 
 	self assert: 6+8 equals: ((PrintfFormatString new setFormat: 'hello %ld') printf: {12345678})
+	! !
+
+!PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 1/15/2022 17:02:07'!
+testThousandSeparator
+       ". small numbers are ignored "
+	self assert: (('%_d' printf: {123}) = '123' ) .
+	self assert: (('%_d' printf: {1234}) = '1_234' ) .
+	self assert: (('%_d' printf: {12345678}) = '12_345_678' ) .
+	". very large numbers must be ok "
+	self assert: (('%_d' printf: {123456789123456789}) = '123_456_789_123_456_789' ) .   
+	
 	! !
 
 !Object methodsFor: '*Printf' stamp: 'NM 8/16/2021 15:08:36'!

--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 11:03:41 pm'!
+'From Cuis 6.0 [latest update: #5041] on 16 January 2022 at 12:30:02 am'!
 'Description '!
-!provides: 'Printf' 1 32!
+!provides: 'Printf' 1 38!
 SystemOrganization addCategory: #Printf!
 
 
@@ -37,7 +37,7 @@ PrintfCharacterFormatDescriptor class
 !classDefinition: #PrintfNumberFormatDescriptor category: #Printf!
 PrintfFormatDescriptor subclass: #PrintfNumberFormatDescriptor
 	instanceVariableNames: 'operator padding radix space thousandSeparate'
-	classVariableNames: 'Base Cased DecimalSeparator Radix ThousandSeparator'
+	classVariableNames: 'Base Cased DecimalSeparator Radix ThousandSeparator UserDecimalSeparator UserThousandSeparator'
 	poolDictionaries: ''
 	category: 'Printf'!
 !classDefinition: 'PrintfNumberFormatDescriptor class' category: #Printf!
@@ -450,7 +450,7 @@ stringLength
 		ifFalse: [precision]
 		! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 16:45:49'!
+!PrintfNumberFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/16/2022 00:02:07'!
 addThousandSeparator: numberString
 	". receives in input an integer numberString e.g. '12345'
 	. returns in output a thousand separated string e.g. '12_345' 
@@ -463,9 +463,10 @@ addThousandSeparator: numberString
 		^ numberString . 
 		].
 	". if we arrived here the base is 10 " 
-	^ numberString asNumber printStringWithCommas :: 
-				copyReplaceAll: ',' with: (thousandSeparator asString)
-	
+	^ self formatWithUserPreferences: ( 
+		(numberString asNumber printStringWithCommas) 
+			copyReplaceAll: ',' with: (self thousandSeparator asString) ) 
+ 	
 	! !
 
 !PrintfNumberFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 16:28:30'!
@@ -490,6 +491,28 @@ applyOperator: object
 		ifTrue: [String new: width withAll: $*]
 		ifFalse: [string]
 		! !
+
+!PrintfNumberFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/16/2022 00:14:50'!
+formatWithUserPreferences: numString
+	". numString is a string representing a number of the kind: 123_456.123.
+	. according to the values in the class variables UserDecimalSeparator and UserThousandSeparator
+	 a string like the following is returned, for example: 123.456,123, which would be appropriate 
+	 for a user in Italy.  
+	" 
+	|userDec userThou tmp|
+	userDec _ self class getUserDecimalSeparator . 
+	userThou _ self class getUserThousandSeparator .
+	". if there aren't user preferences set, then quit and use the default form string. "  
+	((userDec isNil) and: (userThou isNil)) ifTrue: [ ^ numString ].
+	". if any of the user preferences is undefined set it to the default valued " 
+	(userDec isNil) ifTrue: [userDec _ self class getDecimalSeparator ].
+	(userThou isNil) ifTrue: [userThou _ self class getThousandSeparator  ] . 
+	". do the change and return the new formatted string " 
+	tmp _ numString copyReplaceAll: '_' with: 'THO' . 
+	tmp _ tmp copyReplaceAll: '.' with: 'DEC'. 
+	tmp _ tmp copyReplaceAll: 'DEC' with: (userDec asString) . 
+	tmp _ tmp copyReplaceAll: 'THO' with: (userThou asString) . 
+	^ tmp 	! !
 
 !PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 8/16/2021 14:34:07'!
 radix
@@ -538,17 +561,36 @@ newFrom: desc
 	^ (super newFrom: desc) setPadding: desc padding
 	! !
 
-!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 22:50:07'!
+!PrintfNumberFormatDescriptor class methodsFor: 'settings' stamp: 'NM 1/15/2022 22:50:07'!
 getDecimalSeparator
 	^ DecimalSeparator  
 	! !
 
-!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 22:50:26'!
+!PrintfNumberFormatDescriptor class methodsFor: 'settings' stamp: 'NM 1/15/2022 22:50:26'!
 getThousandSeparator
 	^ ThousandSeparator  
 	! !
 
-!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 22:47:01'!
+!PrintfNumberFormatDescriptor class methodsFor: 'settings' stamp: 'NM 1/15/2022 23:18:19'!
+getUserDecimalSeparator
+	^ UserDecimalSeparator  
+	! !
+
+!PrintfNumberFormatDescriptor class methodsFor: 'settings' stamp: 'NM 1/15/2022 23:18:27'!
+getUserThousandSeparator
+	^ UserThousandSeparator  
+	! !
+
+!PrintfNumberFormatDescriptor class methodsFor: 'settings' stamp: 'NM 1/16/2022 00:06:50'!
+setUserDecimalSeparatorTo: aCharacter
+	UserDecimalSeparator _ aCharacter . ! !
+
+!PrintfNumberFormatDescriptor class methodsFor: 'settings' stamp: 'NM 1/16/2022 00:06:56'!
+setUserThousandSeparatorTo: aCharacter
+	UserThousandSeparator _ aCharacter . 
+	! !
+
+!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 23:17:57'!
 initialize
 	"PrintfNumberFormatDescriptor initialize"
 	Base := Dictionary newFromPairs: #(	$d 10
@@ -567,21 +609,18 @@ initialize
 
 	Cased := 'AaEeFfGgXx' . 
 	
+	". default values, don't modify these, test code use them.  "
 	DecimalSeparator _ $.  .
 	ThousandSeparator _ $_ . 
+	". user modifiable values, for example to print numerics in agreement with some locale
+	 . if these values are 'nil' they are ignored. If only one is 'nil' the other is taken from the default values above. 
+	 " 
+	UserDecimalSeparator _ nil. 
+	UserThousandSeparator _ nil. 
 	
 	! !
 
-!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 22:47:19'!
-setDecimalSeparatorTo: aCharacter
-	DecimalSeparator _ aCharacter . ! !
-
-!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 22:42:25'!
-setThousandSeparatorTo: aCharacter
-	ThousandSeparator _ aCharacter . 
-	! !
-
-!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 22:13:24'!
+!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 23:52:47'!
 addThousandSeparator: numberString
 	". receives in input an integer numberString e.g. '12345.1233123'
 	. returns in output a thousand separated string e.g. '12_345.1233123' 
@@ -589,7 +628,7 @@ addThousandSeparator: numberString
 	. if 'base' is not is not 10 returns just 'numberString', since a separation by 3 digits blocks
 	 would not mean what 'thousand' says; in that case also print a warning in the Transcript'. 
 	"
-	|integerPart decimalPart tokens |
+	|integerPart decimalPart tokens out |
 	". TODO. CHECK. we suppose the base is 10 for floats " 
 	"(self base ~= 10) ifTrue:  [ 
 		Transcript log: 'Error. Printf. thousand separation is not defined for non base 10 numbers.' . 
@@ -599,9 +638,11 @@ addThousandSeparator: numberString
 	tokens _ numberString findTokens: '.' . 
 	integerPart _ tokens first.
 	decimalPart _ tokens second. 
-	^ (integerPart asNumber printStringWithCommas :: 
-				copyReplaceAll: ',' with: (thousandSeparator asString) ), 
-				'.' , decimalPart . 
+	". build the default thousand separated numeric string "
+	out _ (integerPart asNumber printStringWithCommas :: 
+		copyReplaceAll: ',' with: (self thousandSeparator asString) ), '.' , decimalPart .
+	". apply user preferences regarding who are thousand and decimal separators "
+	^ self formatWithUserPreferences: out . 	
 	! !
 
 !PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 22:31:19'!
@@ -638,10 +679,9 @@ applyOperator: object
 			
 		! !
 
-!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 21:49:03'!
+!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 23:10:12'!
 initializeThousandSeparatorFrom: descriptor 
 	(descriptor class = PrintfNumberFormatDescriptor) ifTrue: [
-		thousandSeparator _ (descriptor thousandSeparator ).
 		thousandSeparate  _ (descriptor thousandSeparate ).
 		].
 	^ self ! !
@@ -894,6 +934,26 @@ test102_FloatsWithThousandSeparator
 	". digit limiting is by trucation "
 	self assert: (('%_0.2f' printf: {1234.123}) = '1_234.12' ) .
 	self assert: (('%_0.2f' printf: {1234.127}) = '1_234.12' ) .! !
+
+!PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 1/16/2022 00:24:24'!
+test103_UserDefinedThousandAndDecimals
+       ". If the user set nothing number are formatted like this "
+	self assert: (('%_0.2f' printf: {1234.567}) = '1_234.56'  ). 
+	". the underscore may not be liked but it can be userful to re-parse the number,
+	  Perl, Ruby, and recently Python recognize '123_123.12' numbers literals 
+	. here we format the number in the US standard way.
+	"
+	PrintfNumberFormatDescriptor setUserThousandSeparatorTo: $, .
+	self assert: (('%_0.2f' printf: {1234.567}) = '1,234.56'  ).
+	". now let's print the number in the way it is considered 'normal' in Italy, for example " 
+	PrintfNumberFormatDescriptor setUserThousandSeparatorTo: $. .
+	PrintfNumberFormatDescriptor setUserDecimalSeparatorTo: $, .
+	self assert: (('%_0.2f' printf: {1234.567}) = '1.234,56'  ).
+	". and let's put back the default configuaration, since the other test expect that " 
+	PrintfNumberFormatDescriptor setUserThousandSeparatorTo: nil .
+	PrintfNumberFormatDescriptor setUserDecimalSeparatorTo: nil .
+	self assert: (('%_0.2f' printf: {1234.567}) = '1_234.56'  ). 
+	! !
 
 !PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 8/30/2021 18:39:08'!
 testFprintf

--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 5:25:08 pm'!
+'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 5:27:12 pm'!
 'Description '!
-!provides: 'Printf' 1 21!
+!provides: 'Printf' 1 22!
 SystemOrganization addCategory: #Printf!
 
 
@@ -787,13 +787,6 @@ test101_LargeFloat
 
 	! !
 
-!PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 1/15/2022 17:11:35'!
-testBigFloat
-	^ nil 
-      
-	
-	! !
-
 !PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 8/30/2021 18:39:08'!
 testFprintf
 	| stream expected |
@@ -803,17 +796,6 @@ testFprintf
 and a 0-padded limited precision one "%013.5e".'
 		printf: #('long' 'hello world' 'hello world' 42.0 42.1234567)).
 	self assert: expected equals: stream contents
-	! !
-
-!PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 1/15/2022 17:12:50'!
-testLargeFloat101
-       ". small numbers are ignored "
-	self assert: (('%_d' printf: {123}) = '123' ) .
-	self assert: (('%_d' printf: {1234}) = '1_234' ) .
-	self assert: (('%_d' printf: {12345678}) = '12_345_678' ) .
-	". very large numbers must be ok "
-	self assert: (('%_d' printf: {123456789123456789}) = '123_456_789_123_456_789' ) .   
-	
 	! !
 
 !PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 8/16/2021 14:47:49'!

--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 6.0 [latest update: #5041] on 9 January 2022 at 12:31:05 am'!
+'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 4:29:48 pm'!
 'Description '!
-!provides: 'Printf' 1 15!
+!provides: 'Printf' 1 19!
 SystemOrganization addCategory: #Printf!
 
 
@@ -118,10 +118,11 @@ printOn: aStream
 	aStream nextPut: $c
 	! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'printing' stamp: 'NM 1/9/2022 00:30:06'!
+!PrintfNumberFormatDescriptor methodsFor: 'printing' stamp: 'NM 1/15/2022 15:26:57'!
 printOn: aStream
+	Transcript log: '---> called NumFormDescriptor >> printOn: '.
 	super printOn: aStream.
-	thousandSeparate ifTrue: [ aStream nextPut: $' ]. 
+	thousandSeparate ifTrue: [ aStream nextPut: $_ ]. 
 	padding == $0 ifTrue: [aStream nextPut: $0].
 	radix ifTrue: [aStream nextPut: $#].
 	space ifTrue: [aStream nextPut: $ ].
@@ -238,14 +239,9 @@ space
 	^ (PrintfNumberFormatDescriptor newFrom: self) space
 	! !
 
-!PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/8/2022 23:41:24'!
+!PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 15:12:59'!
 thousandSeparate
-	^ (PrintfNumberFormatDescriptor newFrom: self) thousandSeparate 
-	! !
-
-!PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/8/2022 23:41:36'!
-thousandSeparator
-	^ (PrintfNumberFormatDescriptor newFrom: self) thousandSeparator 
+	^ (PrintfNumberFormatDescriptor newFrom: self) thousandSeparate
 	! !
 
 !PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 8/16/2021 14:13:20'!
@@ -379,7 +375,7 @@ scanFrom: stream
 	
 	! !
 
-!PrintfFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/8/2022 23:42:18'!
+!PrintfFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 14:49:18'!
 initialize
 	"PrintfFormatDescriptor initialize"
 	Operators := Dictionary new.
@@ -397,7 +393,7 @@ initialize
 	Flags at: $  put: #space.
 	Flags at: $# put: #radix.
 	Flags at: $0 put: #zero.
-	Flags at: $' put: #thousandSeparate
+	Flags at: $_ put: #thousandSeparate
 	
 	
 	
@@ -440,14 +436,35 @@ stringLength
 		ifFalse: [precision]
 		! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'rendering' stamp: 'NM 8/16/2021 14:33:47'!
+!PrintfNumberFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 16:29:11'!
+addThousandSeparator: numberString
+	". receives in input an integer numberString e.g. '12345'
+	. returns in output a thousand separated string e.g. '12_345' 
+	. '_' is the value lf 'thousandSeparator' 
+	. if 'base' is not is not 10 returns just numberString, since a separation by 3 digits blocks
+	 would not mean what 'thousand' says; and print a warning in the Transcript'. 
+	"
+	(self base ~= 10) ifTrue:  [ 
+		Transcript log: 'Error. Printf. thousand separation is not defined for non base 10 numbers.' . 
+		^ numberString . 
+		].
+	". if we arrived here the base is 10 " 
+	^ numberString asNumber printStringWithCommas :: 
+				copyReplaceAll: ',' with: (thousandSeparator asString)
+	
+	! !
+
+!PrintfNumberFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 16:28:30'!
 applyOperator: object 
 	"Character and Number are the only valid classes"
 
 	| number string |
 	object ifNil: [^'-'].
 	number := object asInteger.
+	
 	string := number printStringBase: self base.
+	". apply thousand separation, if reasonable "
+	thousandSeparate ifTrue: [ string _ self addThousandSeparator: string ] . 
 	(radix or: [operator == $p]) ifTrue: [string := self radixString , string].
 	(Cased includes: operator) ifTrue:
 		[string := operator isLowercase
@@ -470,8 +487,9 @@ space
 	space := true
 	! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/9/2022 00:23:13'!
+!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 15:15:58'!
 thousandSeparate
+	Transcript log: '--> Called thousandSeparate '. 
 	thousandSeparate := true.! !
 
 !PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 8/16/2021 14:34:26'!
@@ -479,7 +497,7 @@ zero
 	padding := $0
 	! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'initialize-release' stamp: 'NM 1/8/2022 23:39:38'!
+!PrintfNumberFormatDescriptor methodsFor: 'initialize-release' stamp: 'NM 1/15/2022 14:47:54'!
 initialize
 	super initialize.
 	padding := $ .
@@ -487,7 +505,7 @@ initialize
 	space := false.
 	thousandSeparate := false .
 	" . TODO temporary value, we should by default set $, if decimal separator is $. and viceversa. "
-	thousandSeparator := $, .! !
+	thousandSeparator := $_ .! !
 
 !PrintfNumberFormatDescriptor class methodsFor: 'instance creation' stamp: 'NM 8/16/2021 14:35:16'!
 newFrom: desc

--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 6.0 [latest update: #5041] on 16 January 2022 at 12:30:02 am'!
+'From Cuis 6.0 [latest update: #5041] on 16 January 2022 at 1:01:33 am'!
 'Description '!
-!provides: 'Printf' 1 38!
+!provides: 'Printf' 1 39!
 SystemOrganization addCategory: #Printf!
 
 
@@ -156,6 +156,58 @@ setFormat: aString
 		with: (String with: Character tab)) readStream.
 	self collectFormatDescriptorsAndStrings: formatStream
 	! !
+
+!Printf methodsFor: 'documentation' stamp: 'NM 1/16/2022 00:42:53'!
+changeLog
+	^ nil 
+"
+
+==== [NM] on 16-jan-2022 =========================
+. Added new test, started numbering of new tests. Easier to reference them, Easier to 
+follow them when studying a new package. PLEASE, keep numbering the test progressively
+if you add more. 
+
+. added support for prettyprintinf float numbers, that is, with thousand separator and decimal
+separator. These can be also set by the user, making the work locale independent. 
+Please see tests 100, 102, 103.
+
+. discovered bug, exposed in test 101, still to be corrected. it relates to the printing of large numbers. 
+
+. added the method 'hackMe' , to contain some minimal documentation about how to add stuff
+to this package. 
+
+=======================================
+"! !
+
+!Printf methodsFor: 'documentation' stamp: 'NM 1/16/2022 00:59:35'!
+hackIt
+	^ nil 
+"
+
+====== [NM] on  16-Jan-2022 =============================
+
+. This package is not so easy to understand, when i started i underestimated the complexity.
+
+. Suppose you are adding a new function character 'z', the first thing you need to get working is
+ the third line, the others are examples. 
+PrintfFormatDescriptor scanFrom: (ReadStream on: 'd'). 
+PrintfFormatDescriptor scanFrom: (ReadStream on: '-s'). 
+PrintfFormatDescriptor scanFrom: (ReadStream on: 'z'). 
+
+. The recognized charactes (%d, %s, %f ... ) and flags are defined in: 
+PrintfFormatDescriptor class >> initialize 
+
+. Who does the number printinting are, for example:
+PrintfNumberFormatDescription >> applyOperator: anObject. 
+  [ the anObject here is for example: 123 ]
+PrintfFloatFormatDescription >> applyOperator: anObject.
+[ the anObject here is for example: 123.123 ] 
+
+
+
+=====================================================
+
+"! !
 
 !Printf methodsFor: 'documentation' stamp: 'NM 8/30/2021 18:56:05'!
 history

--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 5.0 [latest update: #4815] on 30 August 2021 at 6:56:24 pm'!
+'From Cuis 6.0 [latest update: #5041] on 9 January 2022 at 12:31:05 am'!
 'Description '!
-!provides: 'Printf' 1 10!
+!provides: 'Printf' 1 15!
 SystemOrganization addCategory: #Printf!
 
 
@@ -36,7 +36,7 @@ PrintfCharacterFormatDescriptor class
 
 !classDefinition: #PrintfNumberFormatDescriptor category: #Printf!
 PrintfFormatDescriptor subclass: #PrintfNumberFormatDescriptor
-	instanceVariableNames: 'operator padding radix space'
+	instanceVariableNames: 'operator padding radix space thousandSeparate thousandSeparator'
 	classVariableNames: 'Base Cased Radix'
 	poolDictionaries: ''
 	category: 'Printf'!
@@ -118,9 +118,10 @@ printOn: aStream
 	aStream nextPut: $c
 	! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'printing' stamp: 'NM 8/16/2021 14:33:00'!
+!PrintfNumberFormatDescriptor methodsFor: 'printing' stamp: 'NM 1/9/2022 00:30:06'!
 printOn: aStream
 	super printOn: aStream.
+	thousandSeparate ifTrue: [ aStream nextPut: $' ]. 
 	padding == $0 ifTrue: [aStream nextPut: $0].
 	radix ifTrue: [aStream nextPut: $#].
 	space ifTrue: [aStream nextPut: $ ].
@@ -235,6 +236,16 @@ rightFlush
 !PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 8/16/2021 14:12:08'!
 space
 	^ (PrintfNumberFormatDescriptor newFrom: self) space
+	! !
+
+!PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/8/2022 23:41:24'!
+thousandSeparate
+	^ (PrintfNumberFormatDescriptor newFrom: self) thousandSeparate 
+	! !
+
+!PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/8/2022 23:41:36'!
+thousandSeparator
+	^ (PrintfNumberFormatDescriptor newFrom: self) thousandSeparator 
 	! !
 
 !PrintfFormatDescriptor methodsFor: 'scanning' stamp: 'NM 8/16/2021 14:13:20'!
@@ -368,7 +379,7 @@ scanFrom: stream
 	
 	! !
 
-!PrintfFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 8/16/2021 14:19:11'!
+!PrintfFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/8/2022 23:42:18'!
 initialize
 	"PrintfFormatDescriptor initialize"
 	Operators := Dictionary new.
@@ -385,7 +396,11 @@ initialize
 	Flags at: $+ put: #rightFlush.
 	Flags at: $  put: #space.
 	Flags at: $# put: #radix.
-	Flags at: $0 put: #zero
+	Flags at: $0 put: #zero.
+	Flags at: $' put: #thousandSeparate
+	
+	
+	
 	! !
 
 !PrintfCharacterFormatDescriptor methodsFor: 'rendering' stamp: 'NM 8/16/2021 14:23:00'!
@@ -455,18 +470,24 @@ space
 	space := true
 	! !
 
+!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/9/2022 00:23:13'!
+thousandSeparate
+	thousandSeparate := true.! !
+
 !PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 8/16/2021 14:34:26'!
 zero
 	padding := $0
 	! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'initialize-release' stamp: 'NM 8/16/2021 14:32:32'!
+!PrintfNumberFormatDescriptor methodsFor: 'initialize-release' stamp: 'NM 1/8/2022 23:39:38'!
 initialize
 	super initialize.
 	padding := $ .
 	radix := false.
-	space := false
-	! !
+	space := false.
+	thousandSeparate := false .
+	" . TODO temporary value, we should by default set $, if decimal separator is $. and viceversa. "
+	thousandSeparator := $, .! !
 
 !PrintfNumberFormatDescriptor class methodsFor: 'instance creation' stamp: 'NM 8/16/2021 14:35:16'!
 newFrom: desc

--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 9:50:28 pm'!
+'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 10:26:57 pm'!
 'Description '!
-!provides: 'Printf' 1 26!
+!provides: 'Printf' 1 28!
 SystemOrganization addCategory: #Printf!
 
 
@@ -563,11 +563,33 @@ initialize
 	Cased := 'AaEeFfGgXx'
 	! !
 
-!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 18:48:55'!
+!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 22:13:24'!
+addThousandSeparator: numberString
+	". receives in input an integer numberString e.g. '12345.1233123'
+	. returns in output a thousand separated string e.g. '12_345.1233123' 
+	. '_' is the value lf 'thousandSeparator' 
+	. if 'base' is not is not 10 returns just 'numberString', since a separation by 3 digits blocks
+	 would not mean what 'thousand' says; in that case also print a warning in the Transcript'. 
+	"
+	|integerPart decimalPart tokens |
+	". TODO. CHECK. we suppose the base is 10 for floats " 
+	"(self base ~= 10) ifTrue:  [ 
+		Transcript log: 'Error. Printf. thousand separation is not defined for non base 10 numbers.' . 
+		^ numberString . 
+		]."
+	". if we arrived here the base is 10 " 
+	tokens _ numberString findTokens: '.' . 
+	integerPart _ tokens first.
+	decimalPart _ tokens second. 
+	^ (integerPart asNumber printStringWithCommas :: 
+				copyReplaceAll: ',' with: (thousandSeparator asString) ), 
+				'.' , decimalPart . 
+	! !
+
+!PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 22:09:09'!
 applyOperator: object 
 	"Number is the only valid class"
-
-	| string |
+	| string out |
 	string := self zeroPaddedStringOfBase: (('aA' includes: operator)
 												ifTrue: [16]
 												ifFalse: [10])
@@ -581,13 +603,19 @@ applyOperator: object
 					ifFalse: [string asUppercase]].
 	(space and: [object asFloat >= 0]) ifTrue:
 		[string := ' ' , string].
+	out _ (width ~= 0 and: [string size > width])
+			ifTrue: [String new: width withAll: $*]
+			ifFalse: [string].
+	" . add thousand separators, if needed " 
 	Transcript show: 'DBG --- applyOperator for FLoat numbers '.
-	" self halt. " 
-	thousandSeparate ifTrue: [Transcript show: 'DBG --- thousand sep is ON'] 
+	thousandSeparate 
+		ifTrue: [
+			Transcript show: 'DBG --- thousand sep is ON'.
+			out _ self addThousandSeparator: out. 
+			] 
 		ifFalse: [Transcript show: 'DBG --- thousand sep is OFF'] . 
-	^(width ~= 0 and: [string size > width])
-		ifTrue: [String new: width withAll: $*]
-		ifFalse: [string]
+	^ out 		
+			
 		! !
 
 !PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 21:49:03'!
@@ -835,6 +863,17 @@ test101_LargeFloat
 	self assert: ('%.2f' printf: {12345678.1}) = '12345678.10'.  ". gives wrongly 1.23"
 
 	! !
+
+!PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 1/15/2022 22:26:12'!
+test102_FloatsWithThousandSeparator
+       ". Testing the print of floating points with thousand separator "
+	self assert: (('%_0.2f' printf: {1234}) = '1_234.00' ) .
+	self assert: (('%_0.2f' printf: {1234.1}) = '1_234.10' ) .
+	self assert: (('%_0.2f' printf: {1234.12}) = '1_234.12' ) .
+	self assert: (('%_0.2f' printf: {1234.123}) = '1_234.12' ) .
+	". digit limiting is by trucation "
+	self assert: (('%_0.2f' printf: {1234.123}) = '1_234.12' ) .
+	self assert: (('%_0.2f' printf: {1234.127}) = '1_234.12' ) .! !
 
 !PrintfFormatStringTest methodsFor: 'as yet unclassified' stamp: 'NM 8/30/2021 18:39:08'!
 testFprintf

--- a/Packages/Features/Printf.pck.st
+++ b/Packages/Features/Printf.pck.st
@@ -1,6 +1,6 @@
-'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 10:33:57 pm'!
+'From Cuis 6.0 [latest update: #5041] on 15 January 2022 at 11:03:41 pm'!
 'Description '!
-!provides: 'Printf' 1 29!
+!provides: 'Printf' 1 32!
 SystemOrganization addCategory: #Printf!
 
 
@@ -36,8 +36,8 @@ PrintfCharacterFormatDescriptor class
 
 !classDefinition: #PrintfNumberFormatDescriptor category: #Printf!
 PrintfFormatDescriptor subclass: #PrintfNumberFormatDescriptor
-	instanceVariableNames: 'operator padding radix space thousandSeparate thousandSeparator'
-	classVariableNames: 'Base Cased Radix'
+	instanceVariableNames: 'operator padding radix space thousandSeparate'
+	classVariableNames: 'Base Cased DecimalSeparator Radix ThousandSeparator'
 	poolDictionaries: ''
 	category: 'Printf'!
 !classDefinition: 'PrintfNumberFormatDescriptor class' category: #Printf!
@@ -510,14 +510,9 @@ thousandSeparate: aBoolean
 	thousandSeparate _ aBoolean .
 ! !
 
-!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 19:21:01'!
+!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 22:51:02'!
 thousandSeparator
-	^ thousandSeparator
-	! !
-
-!PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 1/15/2022 19:20:47'!
-thousandSeparator: aCharacter
-	thousandSeparator _ aCharacter .
+	^ self class getThousandSeparator 
 	! !
 
 !PrintfNumberFormatDescriptor methodsFor: 'scanning' stamp: 'NM 8/16/2021 14:34:26'!
@@ -543,7 +538,17 @@ newFrom: desc
 	^ (super newFrom: desc) setPadding: desc padding
 	! !
 
-!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 8/16/2021 14:35:00'!
+!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 22:50:07'!
+getDecimalSeparator
+	^ DecimalSeparator  
+	! !
+
+!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 22:50:26'!
+getThousandSeparator
+	^ ThousandSeparator  
+	! !
+
+!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 22:47:01'!
 initialize
 	"PrintfNumberFormatDescriptor initialize"
 	Base := Dictionary newFromPairs: #(	$d 10
@@ -560,7 +565,20 @@ initialize
 											$x '0x'
 											$X '0X').
 
-	Cased := 'AaEeFfGgXx'
+	Cased := 'AaEeFfGgXx' . 
+	
+	DecimalSeparator _ $.  .
+	ThousandSeparator _ $_ . 
+	
+	! !
+
+!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 22:47:19'!
+setDecimalSeparatorTo: aCharacter
+	DecimalSeparator _ aCharacter . ! !
+
+!PrintfNumberFormatDescriptor class methodsFor: 'class initialization' stamp: 'NM 1/15/2022 22:42:25'!
+setThousandSeparatorTo: aCharacter
+	ThousandSeparator _ aCharacter . 
 	! !
 
 !PrintfFloatFormatDescriptor methodsFor: 'rendering' stamp: 'NM 1/15/2022 22:13:24'!


### PR DESCRIPTION
*   printf has a nice feature that let us print big numbers as "1,234.12". We make this available also Cuis printf. 
*   in printf the modifier is $' , i don't want to use that in Cuis because it is our one and only literal string delimiter, so i use $\_ as modifier i.e. %d thousand separated is %\_d, and %0.2f thousand separated would be %\_0.2f
*   I use \_ as default thousand separator in agreement with what Perl, Ruby and recently also Python accept. 
*   The user has possibility of deciding his own thousand and decimal separator. Indeed in Italy for example we would print financial values as e.g. 1,234.12 . 
*   new tests are added
*   new tests are kept separated from the old ones, they are progressively numbered
*   Detected **bug** in existing Printf code, made test to keep it in sight and remember it is there. It is an ugly bug on printing big values. see **test101\_X** .