### PR TITLE
Update runTests.yml

### DIFF
--- a/.github/workflows/runTests.yml
+++ b/.github/workflows/runTests.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: .ContinuousIntegrationScripts/installVm.sh
       - run: .ContinuousIntegrationScripts/installUpdates.sh
       - run: .ContinuousIntegrationScripts/runTests.sh


### PR DESCRIPTION
Try whether this fixes the following warning in GitHub Actions: Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2.