### PR TITLE
FileListWindow: add new method

### DIFF
--- a/CoreUpdates/6018-CuisCore-Zardoz-2023Sep15-15h26m-zrdz.001.cs.st
+++ b/CoreUpdates/6018-CuisCore-Zardoz-2023Sep15-15h26m-zrdz.001.cs.st
@@ -1,0 +1,21 @@
+'From Cuis 6.0 [latest update: #6017] on 15 September 2023 at 3:27:02 pm'!
+
+!FileListWindow class methodsFor: 'instance creation' stamp: 'zrdz 9/15/2023 15:26:32'!
+openFileList: aDirectory
+	"
+	FileListWindow openFileList
+	"
+	| win |
+	
+	win := FileListWindow open: aDirectory label: nil.
+	win model when: #updateButtonRow send: #updateButtonRow to: win.
+	^ win! !
+
+
+!FileListWindow class methodsFor: 'instance creation' stamp: 'zrdz 9/15/2023 15:26:49'!
+openFileList
+	"
+	FileListWindow openFileList
+	"
+	self openFileList: (FileList new directory: DirectoryEntry currentDirectory)! !
+


### PR DESCRIPTION
add way to create a FileListWindow with `FileListWindow class>>openFileList: aDirectory`. Currently only works within a workspace. Example:
```st
FileListWindow openFileList: DirectoryEntry smalltalkImageDirectory.
```