### PR TITLE
Add support for Homebrew libraries

### DIFF
--- a/RunCuisOnMacTerminal.sh
+++ b/RunCuisOnMacTerminal.sh
@@ -1,1 +1,2 @@
+export DYLD_LIBRARY_PATH="$(brew --prefix)/lib:${DYLD_LIBRARY_PATH}"
 ./CuisVM.app/Contents/MacOS/Squeak CuisImage/Cuis?.?-????.image -u


### PR DESCRIPTION
Apple does not allow adding libraries to the library paths in .bash_profile or .zsh_profile. By adding Homebrew to the library path in the launch script this limitation is bypassed.