### PR TITLE
Update AboutCuis.md

### DIFF
--- a/Documentation/AboutCuis.md
+++ b/Documentation/AboutCuis.md
@@ -57,7 +57,7 @@ Cuis is maintained on our [Main GitHub repo](https://github.com/Cuis-Smalltalk/C
 
 This is our main [Project Website](https://www.cuis.st). It includes a general overview of the project. You can find the schedule for our future onlime monthly meetings, and watch video recordings for past ones.
 
-Cuis has an active community of developers and users. Our main meeting point is the [mailing list](https://lists.cuis.st/mailman/listinfo/cuis-dev). You can browse the archives for a glimpse of our discussions. Pre-April-2019 archives are found [here](http://cuis-smalltalk.org/pipermail/cuis-dev_cuis-smalltalk.org/) and [here](http://jvuletich.org/mailman/listinfo/cuis_jvuletich.org). You are welcome here. If you use Cuis or are curious about our work, subscribe to the mail list to ask questions and tell us about your own projects and ideas.
+Cuis has an active community of developers and users. Our main meeting point is the [mailing list](https://lists.cuis.st/mailman/listinfo/cuis-dev). You can browse the archives for a glimpse of our discussions. Pre-April-2019 archives are found [here](http://jvuletich.org/mailman/listinfo/cuis_jvuletich.org). You are welcome here. If you use Cuis or are curious about our work, subscribe to the mail list to ask questions and tell us about your own projects and ideas.
 
 ## Learning about Cuis Smalltalk
 [(back to ToC)](#table-of-contents)


### PR DESCRIPTION
Remove non-functional link to the pre-2019 mailing list archive.