### PR TITLE
FIX VM path in CI scripts

### DIFF
--- a/.ContinuousIntegrationScripts/installUpdates.sh
+++ b/.ContinuousIntegrationScripts/installUpdates.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-IMAGE_FILE="$(ls CuisImage/ | grep 'Cuis7.3-[0-9]\+.image')"
+CURRENT_SCRIPT_FOLDER=$(dirname "$(realpath "$0")")
 
 INSTALL_UPDATES_SCRIPT="\
   Utilities classPool at: #AuthorName put: 'TravisCI'.
@@ -11,17 +11,4 @@ INSTALL_UPDATES_SCRIPT="\
   Smalltalk saveAndQuit.\
 "
 
-installUpdatesLinux() {
-  "$GITHUB_WORKSPACE"/sqcogspur64linux/squeak -vm-display-null CuisImage/"$IMAGE_FILE" -d "$INSTALL_UPDATES_SCRIPT"
-}
-
-installUpdatesMacOS() {
-  /Applications/Squeak.app/Contents/MacOS/Squeak -headless CuisImage/"$IMAGE_FILE" -d "$INSTALL_UPDATES_SCRIPT"
-}
-
-case $RUNNER_OS in
-  "Linux")
-    installUpdatesLinux ;;
-  "macOS")
-    installUpdatesMacOS ;;
-esac
+"$CURRENT_SCRIPT_FOLDER/runCuis.sh" -d "$INSTALL_UPDATES_SCRIPT"

--- a/.ContinuousIntegrationScripts/installUpdates.sh
+++ b/.ContinuousIntegrationScripts/installUpdates.sh
@@ -12,7 +12,7 @@ INSTALL_UPDATES_SCRIPT="\
 "
 
 installUpdatesLinux() {
-  /home/runner/work/Cuis-Smalltalk-Dev/Cuis-Smalltalk-Dev/sqcogspur64linux/squeak -vm-display-null CuisImage/"$IMAGE_FILE" -d "$INSTALL_UPDATES_SCRIPT"
+  "$GITHUB_WORKSPACE"/sqcogspur64linux/squeak -vm-display-null CuisImage/"$IMAGE_FILE" -d "$INSTALL_UPDATES_SCRIPT"
 }
 
 installUpdatesMacOS() {

--- a/.ContinuousIntegrationScripts/installVm.sh
+++ b/.ContinuousIntegrationScripts/installVm.sh
@@ -13,7 +13,10 @@ installVmLinux() {
 
   wget "$BASE_VM_DOWNLOAD_PATH/$VM_FILENAME.tar.gz"
   tar -xvzf "$VM_FILENAME.tar.gz"
-  sqcogspur64linux/squeak --version
+
+  CUIS_VM_PATH="$GITHUB_WORKSPACE"/sqcogspur64linux/squeak
+  CUIS_VM_ARGUMENTS="-vm-display-null"
+  "$CUIS_VM_PATH" --version
 }
 
 installVmMacOS() {
@@ -23,6 +26,10 @@ installVmMacOS() {
   sudo hdiutil attach "$VM_FILENAME.dmg"
   cd "/Volumes/$VM_FILENAME"
   sudo cp -rf Squeak.app /Applications
+
+  CUIS_VM_PATH=/Applications/Squeak.app/Contents/MacOS/Squeak
+  CUIS_VM_ARGUMENTS="-headless"
+  "$CUIS_VM_PATH" -version
 }
 
 case $RUNNER_OS in
@@ -31,3 +38,7 @@ case $RUNNER_OS in
   "macOS")
     installVmMacOS ;;
 esac
+
+# Make the environment variables available to other scripts
+echo "CUIS_VM_PATH=$CUIS_VM_PATH" >> "$GITHUB_ENV"
+echo "CUIS_VM_ARGUMENTS=$CUIS_VM_ARGUMENTS" >> "$GITHUB_ENV"

--- a/.ContinuousIntegrationScripts/runCuis.sh
+++ b/.ContinuousIntegrationScripts/runCuis.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE_FILE="$(ls CuisImage/ | grep 'Cuis7.3-[0-9]\+.image')"
+
+"$CUIS_VM_PATH" "$CUIS_VM_ARGUMENTS" CuisImage/"$IMAGE_FILE" "$@"

--- a/.ContinuousIntegrationScripts/runTests.sh
+++ b/.ContinuousIntegrationScripts/runTests.sh
@@ -2,20 +2,6 @@
 
 set -euo pipefail
 
-IMAGE_FILE="$(ls CuisImage/ | grep 'Cuis7.3-[0-9]\+.image')"
-RUN_TESTS_SCRIPT_FILEPATH=".ContinuousIntegrationScripts/runTests.st"
+CURRENT_SCRIPT_FOLDER=$(dirname "$(realpath "$0")")
 
-runTestsOnLinux() {
-  "$GITHUB_WORKSPACE"/sqcogspur64linux/squeak -vm-display-null CuisImage/"$IMAGE_FILE" -s "$RUN_TESTS_SCRIPT_FILEPATH"
-}
-
-runTestsOnMacOS() {
-  /Applications/Squeak.app/Contents/MacOS/Squeak -headless CuisImage/"$IMAGE_FILE" -s "$RUN_TESTS_SCRIPT_FILEPATH"
-}
-
-case $RUNNER_OS in
-  "Linux")
-    runTestsOnLinux ;;
-  "macOS")
-    runTestsOnMacOS ;;
-esac
+"$CURRENT_SCRIPT_FOLDER/runCuis.sh" -s .ContinuousIntegrationScripts/runTests.st

--- a/.ContinuousIntegrationScripts/runTests.sh
+++ b/.ContinuousIntegrationScripts/runTests.sh
@@ -6,7 +6,7 @@ IMAGE_FILE="$(ls CuisImage/ | grep 'Cuis7.3-[0-9]\+.image')"
 RUN_TESTS_SCRIPT_FILEPATH=".ContinuousIntegrationScripts/runTests.st"
 
 runTestsOnLinux() {
-  /home/runner/work/Cuis-Smalltalk-Dev/Cuis-Smalltalk-Dev/sqcogspur64linux/squeak -vm-display-null CuisImage/"$IMAGE_FILE" -s "$RUN_TESTS_SCRIPT_FILEPATH"
+  "$GITHUB_WORKSPACE"/sqcogspur64linux/squeak -vm-display-null CuisImage/"$IMAGE_FILE" -s "$RUN_TESTS_SCRIPT_FILEPATH"
 }
 
 runTestsOnMacOS() {


### PR DESCRIPTION
**Before this PR**
The path to the linux VM was hardcoded (it was assumed that the cloned repo was named `Cuis-Smalltalk-Dev`).
This caused forks (where the repo name changes, like the one in this PR) to fail CI jobs in Linux (OSX path was OK as it doesn't depend on the repo name).

**After this PR**
`$GITHUB_WORKSPACE` (which points to the cloned repo folder in the GitHub Runner) is used to build the VM path in linux to avoid the issue mentioned above.

Additionally, I found that the way Cuis was launched was duplicated (passing the right headless argument to the VM depending on the platform and looking for the Cuis image to load).
This duplication was removed by moving the VM path and its platform-dependent arguments to environment variables.
The `runCuis.sh` scripts runs the VM using those env vars and is responsible for locating the Cuis image.

**Notes**
For more information, please see commit messages.