### PR TITLE
Disables sound for Linux CI jobs

### DIFF
--- a/.ContinuousIntegrationScripts/installVm.sh
+++ b/.ContinuousIntegrationScripts/installVm.sh
@@ -5,12 +5,9 @@ set -euo pipefail
 echo "Setting up VM for $RUNNER_OS"
 
 installVmLinux() {
-  sudo apt-get update
-  sudo apt-get install pulseaudio
-
   #Use VM included with Cuis in this repo
   CUIS_VM_PATH=CuisVM.app/Contents/Linux-x86_64/squeak
-  CUIS_VM_ARGUMENTS="-vm-display-null"
+  CUIS_VM_ARGUMENTS="-vm-sound-null -vm-display-null"
   pwd
   "$CUIS_VM_PATH" --version
 }

--- a/.ContinuousIntegrationScripts/runCuis.sh
+++ b/.ContinuousIntegrationScripts/runCuis.sh
@@ -3,4 +3,5 @@ set -euo pipefail
 
 IMAGE_FILE="$(ls CuisImage/ | grep 'Cuis7.3-[0-9]\+.image')"
 
-"$CUIS_VM_PATH" "$CUIS_VM_ARGUMENTS" CuisImage/"$IMAGE_FILE" "$@"
+# $CUIS_VM_ARGUMENTS should not be quoted to ensure each argument is passed separately
+"$CUIS_VM_PATH" $CUIS_VM_ARGUMENTS CuisImage/"$IMAGE_FILE" "$@"


### PR DESCRIPTION
Before this PR, running the Linux VM required `apt-get update` and installing `pulseaudio`, which slowed down CI jobs.

To address this, the `-vm-sound-null` argument was added to the Linux VM setup.
Additionally, `runCuis.sh` was updated to ensure multiple arguments in `CUIS_VM_ARGUMENTS` are correctly passed to the VM.

This change reduces Linux job times by ~50%.
Notice the time change in the `installVm.sh` section:
* Before: https://github.com/Cuis-Smalltalk/Cuis-Smalltalk-Dev/actions/runs/13088675119/job/36522841004
* After: https://github.com/Cuis-Smalltalk/Cuis-Smalltalk-Dev/actions/runs/13434600244/job/37533922513