### PR TITLE
Fixes compatibility with some linux distros

### DIFF
--- a/CuisVM.app/Contents/Linux-arm64/squeak
+++ b/CuisVM.app/Contents/Linux-arm64/squeak
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Run the VM, setting SQUEAK_PLUGINS if unset to the VM's containing directory
 # if unset, and ensuring LD_LIBRARY_PATH includes the VM's containing directory.
-BIN=`/usr/bin/dirname "$0"`/lib/squeak/7.0-202608060206-64bit
+BIN=`/usr/bin/env dirname "$0"`/lib/squeak/7.0-202608060206-64bit
 GDB=
 if [ "${SQUEAK_PLUGINS-unset}" = unset ]; then
 	export SQUEAK_PLUGINS="$BIN"
@@ -26,7 +26,7 @@ fi
 # libc (e.g. through the FFI) then it must use the same version that the VM uses
 # and so it should take precedence over /lib libc.  This is done by setting
 # LD_LIBRARY_PATH appropriately, based on ldd's idea of the libc use by the VM.
-LIBC_SO="`/usr/bin/ldd "$BIN/squeak" | /bin/fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
+LIBC_SO="`/usr/bin/env ldd "$BIN/squeak" | /usr/bin/env fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
 PLATFORMLIBDIR=`expr "$LIBC_SO" : '\(.*\)/libc.*'`
 
 if [ "$PLATFORMLIBDIR" = "" ]; then

--- a/CuisVM.app/Contents/Linux-x86_64/squeak
+++ b/CuisVM.app/Contents/Linux-x86_64/squeak
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env sh
 # Run the VM, setting SQUEAK_PLUGINS if unset to the VM's containing directory
 # if unset, and ensuring LD_LIBRARY_PATH includes the VM's containing directory.
-BIN=`/usr/bin/dirname "$0"`/lib/squeak/7.0-202608060206-64bit
+BIN=`/usr/bin/env dirname "$0"`/lib/squeak/7.0-202608060206-64bit
 GDB=
 if [ "${SQUEAK_PLUGINS-unset}" = unset ]; then
 	export SQUEAK_PLUGINS="$BIN"
@@ -26,7 +26,7 @@ fi
 # libc (e.g. through the FFI) then it must use the same version that the VM uses
 # and so it should take precedence over /lib libc.  This is done by setting
 # LD_LIBRARY_PATH appropriately, based on ldd's idea of the libc use by the VM.
-LIBC_SO="`/usr/bin/ldd "$BIN/squeak" | /bin/fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
+LIBC_SO="`/usr/bin/env ldd "$BIN/squeak" | /usr/bin/env fgrep /libc. | sed 's/^.*=> \([^ ]*\).*/\1/'`"
 PLATFORMLIBDIR=`expr "$LIBC_SO" : '\(.*\)/libc.*'`
 
 if [ "$PLATFORMLIBDIR" = "" ]; then


### PR DESCRIPTION
Good day,

This small pull request fixes compatibility with NixOS, it is the same logic that is used in .sh scripts, just replacing direct binary path with /usr/bin/env calls first.

Kind regards